### PR TITLE
implement jet for bp-ntt

### DIFF
--- a/crates/zkvm-jetpack/src/hot.rs
+++ b/crates/zkvm-jetpack/src/hot.rs
@@ -9,6 +9,7 @@ use crate::jets::fext_jets::*;
 use crate::jets::mary_jets::*;
 use crate::jets::tip5_jets::*;
 use crate::jets::verifier_jets::*;
+use crate::jets::stark_jets::stark_ntt_jet;
 
 pub fn produce_prover_hot_state() -> Vec<HotEntry> {
     let mut jets: Vec<HotEntry> = Vec::new();
@@ -389,6 +390,20 @@ pub const BASE_POLY_JETS: &[HotEntry] = &[
         ],
         1,
         bp_hadamard_jet,
+    ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"bp-ntt"),
+        ],
+        2,
+        stark_ntt_jet,
     ),
 ];
 

--- a/crates/zkvm-jetpack/src/jets/mod.rs
+++ b/crates/zkvm-jetpack/src/jets/mod.rs
@@ -7,3 +7,4 @@ pub mod mary_jets;
 pub mod tip5_jets;
 pub mod utils;
 pub mod verifier_jets;
+pub mod stark_jets;

--- a/crates/zkvm-jetpack/src/jets/stark_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/stark_jets.rs
@@ -1,0 +1,109 @@
+//! jets/stark_jets.rs
+//!
+//! Native Rust jet for forward NTT (`bp-ntt`).
+
+use nockvm::interpreter::Context;
+use nockvm::jets::util::slot;
+use nockvm::jets::JetErr;
+use nockvm::noun::{Noun, CellMemory, NounAllocator};
+use crate::form::math::base::PRIME;
+
+/// STARK base field modulus: 2^64 − 2^32 + 1
+const MOD: u64 = PRIME;
+
+/// Fast modular exponentiation.
+#[inline(always)]
+fn mod_exp(mut base: u64, mut exp: u64) -> u64 {
+    let mut acc = 1u64;
+    base %= MOD;
+    while exp != 0 {
+        if (exp & 1) != 0 {
+            acc = ((acc as u128 * base as u128) % (MOD as u128)) as u64;
+        }
+        base = ((base as u128 * base as u128) % (MOD as u128)) as u64;
+        exp >>= 1;
+    }
+    acc
+}
+
+/// In-place Cooley–Tuk radix-2 NTT.
+#[inline(always)]
+fn radix2_ntt_inplace(a: &mut [u64], root: u64) {
+    let n = a.len();
+    assert!(n.is_power_of_two(), "NTT size must be a power of two");
+
+    // Bit-reversal permutation
+    {
+        let mut j = 0;
+        for i in 1..n {
+            let mut bit = n >> 1;
+            while (j & bit) != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j |= bit;
+            if i < j {
+                a.swap(i, j);
+            }
+        }
+    }
+
+    // Cooley–Tukey butterfly loops
+    let mut len = 2;
+    while len <= n {
+        let wlen = mod_exp(root, (n / len) as u64);
+        for i in (0..n).step_by(len) {
+            let mut w = 1u64;
+            for j in 0..(len / 2) {
+                let u = a[i + j];
+                let v = ((a[i + j + len / 2] as u128 * w as u128) % (MOD as u128)) as u64;
+                a[i + j] = (u + v) % MOD;
+                a[i + j + len / 2] = (u + MOD - v) % MOD;
+                w = ((w as u128 * wlen as u128) % (MOD as u128)) as u64;
+            }
+        }
+        len <<= 1;
+    }
+}
+
+/// Convert a Hoon list of atoms into a `Vec<u64>`.
+fn list_to_vec_atoms(mut list: Noun) -> Result<Vec<u64>, JetErr> {
+    let mut out = Vec::new();
+    while let Ok(cell) = list.as_cell() {
+        let atom = cell.head().as_direct()?;
+        out.push(atom.data());
+        list = cell.tail();
+    }
+    Ok(out)
+}
+
+/// The hot-entry for `%stark-ntt` (forward NTT).
+/// Expects a 2-cell `[ bpoly , root ]`.
+pub fn stark_ntt_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
+    // Extract the “door” and its arguments
+    let door      = slot(subject, 7)?;
+    let bp_noun   = slot(door,   6)?;
+    let root_noun = slot(door,   7)?;
+
+    // Deserialize bpoly into Vec<u64>
+    let mut data = list_to_vec_atoms(bp_noun)?;
+    let root = root_noun.as_direct()?.data();
+
+    // Perform the in-place NTT
+    radix2_ntt_inplace(&mut data, root);
+
+    // Pack Vec<u64> back into a Hoon list: empty list = raw 0
+    let mut list_n = unsafe { Noun::from_raw(0) };
+    for &x in data.iter().rev() {
+        let atom_n = unsafe { Noun::from_raw(x) };
+        // allocate a new cons-cell
+        let cell_ptr: *mut CellMemory = unsafe { context.stack.alloc_cell() };
+        unsafe {
+            (*cell_ptr).head = atom_n.into();
+            (*cell_ptr).tail = list_n.into();
+        }
+        list_n = unsafe { Noun::from_raw(cell_ptr as u64) };
+    }
+
+    Ok(list_n)
+}

--- a/hoon/common/ztd/two.hoon
+++ b/hoon/common/ztd/two.hoon
@@ -474,9 +474,8 @@
   %+  fmul  (fpow root i)
   (~(snag fop odds) (mod i half))
 ::
-::  +bp-ntt: ntt over base field
-++  bp-ntt
-  ~/  %bp-ntt
+::  +bp-ntt-body: ntt over base field
+++  bp-ntt-body
   |=  [bp=bpoly root=belt]
   ^-  bpoly
   ~+
@@ -486,7 +485,7 @@
   ?>  =((bpow root len.bp) 1)
   ?<  =((bpow root half) 1)
   =/  odds
-    %+  bp-ntt
+    %+  bp-ntt-body
       %-  init-bpoly
       %+  murn  (range len.bp)
       |=  i=@
@@ -495,7 +494,7 @@
       `(~(snag bop bp) i)
     (bmul root root)
   =/  evens
-    %+  bp-ntt
+    %+  bp-ntt-body
       %-  init-bpoly
       %+  murn  (range len.bp)
       |=  i=@
@@ -509,6 +508,14 @@
   %+  badd  (~(snag bop evens) (mod i half))
   %+  bmul  (bpow root i)
   (~(snag bop odds) (mod i half))
+::
+::  +bp-ntt: ntt over base field
+++  bp-ntt
+  ~/  %stark-ntt
+  |=  [bp=bpoly root=belt]
+  ^-  bpoly
+  (bp-ntt-body bp root)
+
 ::
 ::  +fp-fft: Discrete Fourier Transform (DFT) with Fast Fourier Transform (FFT) algorithm
 ++  fp-fft


### PR DESCRIPTION
This PR attempts to implement a jet for the bp-ntt gate, which performs the Number Theoretic Transform (NTT) over the STARK base field. This optimization targets a bottleneck within Nockchain's prover.