### PR TITLE
Restart mining on restart

### DIFF
--- a/hoon/apps/dumbnet/inner.hoon
+++ b/hoon/apps/dumbnet/inner.hoon
@@ -840,7 +840,7 @@
         ::~&  >  'generation of candidate blocks enabled.'
         =.  m.k  (set-mining:min p.command)
         =.  m.k  (heard-new-block:min c.k p.k now)
-        `k
+        (do-mine (hash-noun-varlen:tip5:zeke [%nonce eny]))
       ::
       ++  do-timer
         ::TODO post-dumbnet: only rerequest transactions a max of once/twice (maybe an admin param)


### PR DESCRIPTION
~~5 billion years from now, when the first reference miner's proof gets computed (and inevitably gets rejected by type mismatch), the person mining the proof will be sad to see:~~

~~1. Their proof is 4 million blocks out of date~~
~~2. Their node does not automatically restart mining the new block~~

~~This PR aims at fixing the second issue.~~

~~First issue is considered trivial and left as an exercise to the reader.~~

The actual issue: if you restart your node while it's mining, it will not start mining from the get-go. It will wait until new block arrives for do-mine to get triggered.

This is actually why so many people's nodes were almost idling at launch - it would take hours for people's miners to get kicked.

As far as the state is concerned - the node is mining, but when you restart the nockapp, the mining driver does not actually get triggered.