### PR TITLE
jets: reconnect bp_ntt_jet

### DIFF
--- a/crates/zkvm-jetpack/src/hot.rs
+++ b/crates/zkvm-jetpack/src/hot.rs
@@ -406,6 +406,20 @@ pub const BASE_POLY_JETS: &[HotEntry] = &[
         1,
         bp_hadamard_jet,
     ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"bp-ntt"),
+        ],
+        1,
+        bp_ntt_jet,
+    ),
 ];
 
 pub const ZTD_JETS: &[HotEntry] = &[(


### PR DESCRIPTION
Hooks up `bp_ntt_jet` in zkvm-jetpack. Minimal diff here.