### PR TITLE
jets: bp-ifft

### DIFF
--- a/crates/zkvm-jetpack/src/form/math/bpoly.rs
+++ b/crates/zkvm-jetpack/src/form/math/bpoly.rs
@@ -214,6 +214,22 @@ pub fn bp_fft(bp: &[Belt]) -> Result<Vec<Belt>, FieldError> {
     Ok(bp_ntt(bp, &root))
 }
 
+#[inline(always)]
+pub fn bp_ifft(bp: &[Belt], root: &Belt) -> Result<Vec<Belt>, FieldError> {
+    let n = bp.len() as u64;
+    if n == 0 {
+        return Ok(vec![]);
+    }
+    let inv_root = root.inv();
+    let mut result = bp_ntt(bp, &inv_root);
+    let n_belt = Belt(n);
+    let n_inv = n_belt.inv();
+    for coeff in result.iter_mut() {
+        *coeff = *coeff * n_inv;
+    }
+    Ok(result)
+}
+
 pub fn bp_ntt(bp: &[Belt], root: &Belt) -> Vec<Belt> {
     let n = bp.len() as u32;
 

--- a/crates/zkvm-jetpack/src/hot.rs
+++ b/crates/zkvm-jetpack/src/hot.rs
@@ -464,6 +464,20 @@ pub const BASE_POLY_JETS: &[HotEntry] = &[
         1,
         bp_fft_jet,
     ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"bp-ifft"),
+        ],
+        1,
+        bp_ifft_jet,
+    ),
 ];
 
 pub const ZTD_JETS: &[HotEntry] = &[(

--- a/crates/zkvm-jetpack/src/jets/bp_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/bp_jets.rs
@@ -189,6 +189,33 @@ pub fn bp_fft_jet(context: &mut Context, subject: Noun) -> Result {
     Ok(res_cell)
 }
 
+pub fn bp_ifft_jet(context: &mut Context, subject: Noun) -> Result {
+    let p = slot(subject, 6)?;
+
+    let Ok(p_poly) = BPolySlice::try_from(p) else {
+        return jet_err();
+    };
+    let order_atom = Atom::new(&mut context.stack, p_poly.len() as u64);
+    let Ok(order_belt) = order_atom.as_belt() else {
+        return jet_err();
+    };
+    let Ok(root_belt) = order_belt.ordered_root() else {
+        return jet_err();
+    };
+    let inv_root_belt = root_belt.inv();
+    let Ok(returned_bpoly) = bp_ifft(p_poly.0, &inv_root_belt) else {
+        return jet_err();
+    };
+    let (res_atom, res_poly): (IndirectAtom, &mut [Belt]) =
+        new_handle_mut_slice(&mut context.stack, Some(returned_bpoly.len()));
+
+    res_poly.copy_from_slice(&returned_bpoly);
+
+    let res_cell: Noun = finalize_poly(&mut context.stack, Some(res_poly.len()), res_atom);
+
+    Ok(res_cell)
+}
+
 pub fn bp_shift_jet(context: &mut Context, subject: Noun) -> Result {
     let sam = slot(subject, 6)?;
     let bp = slot(sam, 2)?;


### PR DESCRIPTION
Implements `bp_ifft` by introducing two new functions.

`bp_ifft`: the heart of the inverse FFT logic.
`bp_ifft_jet`: a wrapper to use it.
