### PR TITLE
Fix miner<-->dumb type mismatch

### DIFF
--- a/hoon/apps/dumbnet/lib/types.hoon
+++ b/hoon/apps/dumbnet/lib/types.hoon
@@ -91,7 +91,7 @@
 ::
 +$  command
   $+  command
-  $%  [%pow prf=proof:sp dig=tip5-hash-atom:zeke bc=digest:tip5:zeke nonce=noun-digest:tip5:zeke] :: check if a proof of work is good for the next block, issue a block if so
+  $%  [%pow prf=proof:sp dig=tip5-hash-atom:zeke bc=noun-digest:tip5:zeke nonce=noun-digest:tip5:zeke] :: check if a proof of work is good for the next block, issue a block if so
       [%set-mining-key p=@t]  ::  set $lock for coinbase in mined blocks
       [%set-mining-key-advanced p=(list [share=@ m=@ keys=(list @t)])]  :: multisig and/or split coinbases
       [%enable-mining p=?]  ::  switch for generating candidate blocks for mining


### PR DESCRIPTION
As it currently stands, main loop will reject a valid proof coming from the miner, because input and output bc on the miner is of type `noun-digest:tip5`, while the main loop expects `digest:tip5` back. This PR addresses the issue, enabling the possibility of mining blocks on the client.