### PR TITLE
add rust github action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,37 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+
+
+  test: 
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Run tests
+      run: cargo test --verbose
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Run tests
+      run: cargo clippy --fix
+  
+   


### PR DESCRIPTION
In telegram, a user requested a github action that does multiplatform builds.  I think this makes a lot of sense, so this is an initial PR to pass the concept by the zorp team and if this PR is accepted, we'll move onto one that does mac/windows/linux all at once.

This PR:

* builds nockchain
* tests nockchain
* clippy's nockchain

for now, all of these are done on ubuntu but if this is a good PR, we can easily add mac and windows and building binaries.

