### PR TITLE
Jets rip_correct_jet, based_one_jet, fet_jet, lift_elt_jet

### DIFF
--- a/crates/nockvm/rust/nockvm/src/jets/hot.rs
+++ b/crates/nockvm/rust/nockvm/src/jets/hot.rs
@@ -785,6 +785,16 @@ pub const URBIT_HOT_STATE: &[HotEntry] = &[
         1,
         jet_sivc_de,
     ),
+    (
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"levy")],
+        1,
+        jet_levy,
+    ),
+    (
+        &[K_138, Left(b"one"), Left(b"two"), Left(b"reap")],
+        1,
+        jet_reap,
+    ),
 ];
 
 #[derive(Copy, Clone)]

--- a/crates/zkvm-jetpack/src/hot.rs
+++ b/crates/zkvm-jetpack/src/hot.rs
@@ -191,6 +191,64 @@ pub const XTRA_JETS: &[HotEntry] = &[
         1,
         mp_substitute_mega_jet,
     ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"rip-correct")
+        ],
+        1,
+        rip_correct_jet,
+    ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"based")
+        ],
+        1,
+        based_one_jet,
+    ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"mary-utils"),
+            Left(b"fet")
+        ],
+        1,
+        fet_jet,
+    ),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"zeke"),
+            Left(b"mary-utils"),
+            Left(b"lift-elt")
+        ],
+        1,
+        lift_elt_jet,
+    ),
 ];
 
 pub const EXTENSION_FIELD_JETS: &[HotEntry] = &[

--- a/crates/zkvm-jetpack/src/jets/base_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/base_jets.rs
@@ -1,9 +1,10 @@
 use nockvm::interpreter::Context;
-use nockvm::jets::util::slot;
+use nockvm::jets::util::{bite, slot};
 use nockvm::jets::Result;
-use nockvm::noun::{Atom, Noun};
+use nockvm::noun::{Atom, Noun, D, NO, T, YES};
 use tracing::debug;
-
+use nockvm::jets::bits::util::rip;
+use nockvm::mem::NockStack;
 use crate::form::math::base::*;
 use crate::form::poly::*;
 use crate::jets::utils::*;
@@ -98,4 +99,48 @@ pub fn bpow_jet(context: &mut Context, subject: Noun) -> Result {
     let (x_belt, n_belt) = (x_atom.as_u64()?, n_atom.as_u64()?);
 
     Ok(Atom::new(&mut context.stack, bpow(x_belt, n_belt)).as_noun())
+}
+
+
+pub fn rip_correct_jet(context: &mut Context, subject: Noun) -> Result {
+    let stack = &mut context.stack;
+    let sam = slot(subject, 6)?;
+    let a_noun = slot(sam, 2)?;
+    let b_noun = slot(sam, 3)?;
+
+    let b = b_noun.as_atom()?;
+    let (bloq, step) = bite(a_noun)?;
+    rip_correct(stack, bloq, step, b)
+}
+
+pub fn rip_correct(stack: &mut NockStack, bloq: usize, step: usize, b: Atom) -> Result {
+    if b.is_direct() && b.as_u64()? == 0 {
+        return Ok(T(stack, &[D(0), D(0)]));
+    }
+    rip(stack, bloq, step, b)
+}
+
+pub fn levy_based(a_noun: Noun) -> bool {
+    let mut list = a_noun;
+    loop {
+        if unsafe { list.raw_equals(&D(0)) } {
+            return true;
+        }
+        let cell = list.as_cell().expect("cell not found");
+        let based_res = based_one(cell.head());
+        if !based_res { return false; }
+
+        list = cell.tail();
+    }
+}
+
+pub fn based_one_jet(context: &mut Context, subject: Noun) -> Result {
+    let sam = slot(subject, 6)?;
+    if based_one(sam) { Ok(YES) } else { Ok(NO) }
+}
+
+fn based_one(a_noun: Noun) -> bool {
+    let a = a_noun.as_atom().expect("a not atom");
+    let a_u64 = a.as_u64().expect("a not u64");
+    a_u64 < PRIME
 }

--- a/crates/zkvm-jetpack/src/jets/bp_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/bp_jets.rs
@@ -228,21 +228,23 @@ pub fn bp_coseword_jet(context: &mut Context, subject: Noun) -> Result {
     Ok(res_cell)
 }
 
+
 pub fn init_bpoly_jet(context: &mut Context, subject: Noun) -> Result {
+    let stack = &mut context.stack;
     let poly = slot(subject, 6)?;
 
     let list_belt = HoonList::try_from(poly)?.into_iter();
     let count = list_belt.count();
-    let (res, res_poly): (IndirectAtom, &mut [Belt]) =
-        new_handle_mut_slice(&mut context.stack, Some(count as usize));
+    let (res, res_poly): (IndirectAtom, &mut [Belt]) = new_handle_mut_slice(stack, Some(count));
+    init_bpoly(list_belt, res_poly);
+
+    let res_cell = finalize_poly(stack, Some(res_poly.len()), res);
+    Ok(res_cell)
+}
+
+pub fn init_bpoly(list_belt: HoonList, res_poly: &mut [Belt]) {
     for (i, belt_noun) in list_belt.enumerate() {
-        let Ok(belt) = belt_noun.as_belt() else {
-            return jet_err();
-        };
+        let belt = belt_noun.as_belt().expect("error at as_belt");
         res_poly[i] = belt;
     }
-
-    let res_cell = finalize_poly(&mut context.stack, Some(res_poly.len()), res);
-
-    Ok(res_cell)
 }

--- a/crates/zkvm-jetpack/src/jets/mary_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/mary_jets.rs
@@ -1,12 +1,16 @@
 use nockvm::interpreter::Context;
 use nockvm::jets::util::slot;
 use nockvm::jets::JetErr;
-use nockvm::noun::{IndirectAtom, Noun};
+use nockvm::noun::{IndirectAtom, Noun, D, NO, T, YES};
 use tracing::debug;
-
+use nockvm::jets::list::util::{lent, reap};
+use crate::form::Belt;
 use crate::form::mary::*;
 use crate::form::math::mary::*;
-use crate::hand::handle::{finalize_mary, new_handle_mut_mary};
+use crate::hand::handle::{finalize_mary, finalize_poly, new_handle_mut_mary, new_handle_mut_slice};
+use crate::hand::structs::HoonList;
+use crate::jets::base_jets::{levy_based, rip_correct};
+use crate::jets::bp_jets::init_bpoly;
 use crate::jets::utils::jet_err;
 
 pub fn mary_swag_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
@@ -84,3 +88,44 @@ pub fn mary_transpose_jet(context: &mut Context, subject: Noun) -> Result<Noun, 
 
     Ok(res_cell)
 }
+
+
+pub fn lift_elt_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
+    let stack = &mut context.stack;
+    let door = slot(subject, 7)?;
+    let step = slot(door, 6)?.as_atom()?.as_u64()?;
+    let a = slot(subject, 6)?;
+
+    if step == 1u64 {
+        Ok(a)
+    } else {
+        let reap_res = reap(stack, step-1, D(0))?;
+        let init_bpoly_arg = T(stack, &[a, reap_res]);
+        let init_bpoly_arg_list = HoonList::try_from(init_bpoly_arg)?;
+
+        let count = init_bpoly_arg_list.count();
+        let (res, res_poly): (IndirectAtom, &mut [Belt]) = new_handle_mut_slice(stack, Some(count));
+        init_bpoly(init_bpoly_arg_list, res_poly);
+
+        let res_cell = finalize_poly(stack, Some(res_poly.len()), res);
+        Ok(res_cell.as_cell()?.tail())
+    }
+}
+
+pub fn fet_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
+    let stack = &mut context.stack;
+    let door = slot(subject, 7)?;
+    let step = slot(door, 6)?.as_atom()?.as_u64()?;
+    let a = slot(subject, 6)?.as_atom()?;
+
+    let v = rip_correct(stack, 6, 1, a)?;
+
+    let lent_v = lent(v)? as u64;
+
+    if ((lent_v==1) && (step == 1)) || (lent_v==(step+1)) && levy_based(v) {
+        Ok(YES)
+    } else {
+        Ok(NO)
+    }
+}
+


### PR DESCRIPTION
this commit incorporates the changes from jets_reap_levy, as I need reap() from there.
if one wants to test this branch standalone (without the levy/reap jets), you can comment out the jets jet_levy / jet_reap in nockvm hot.rs