### PR TITLE
Correct and re-enable extend/funcs/memory-table jet

### DIFF
--- a/crates/zkvm-jetpack/src/hot.rs
+++ b/crates/zkvm-jetpack/src/hot.rs
@@ -28,21 +28,21 @@ pub fn produce_prover_hot_state() -> Vec<HotEntry> {
 }
 
 pub const ZKVM_TABLE_JETS: &[HotEntry] = &[
-    //(
-    //    &[
-    //        K_138,
-    //        Left(b"one"),
-    //        Left(b"two"),
-    //        Left(b"tri"),
-    //        Left(b"qua"),
-    //        Left(b"pen"),
-    //        Left(b"memory-table"),
-    //        Left(b"funcs"),
-    //        Left(b"extend"),
-    //    ],
-    //    1,
-    //    memory_extend_jet,
-    //),
+    (
+        &[
+            K_138,
+            Left(b"one"),
+            Left(b"two"),
+            Left(b"tri"),
+            Left(b"qua"),
+            Left(b"pen"),
+            Left(b"memory-table"),
+            Left(b"funcs"),
+            Left(b"extend"),
+        ],
+        1,
+        memory_extend_jet,
+    ),
     (
         &[
             K_138,

--- a/crates/zkvm-jetpack/src/jets/memory_table_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/memory_table_jets.rs
@@ -127,9 +127,10 @@ pub fn memory_extend_jet(context: &mut Context, subject: Noun) -> Result<Noun, J
         write_pelt(&mut res_mary, &inv, &row_idx, &Col(ext_idx(INV_IDX)));
     });
 
-    // padded columns are all 0 except for %inv which is -1
+    // padded columns are all 0 except for %inv which is -1, and %input
     let neg_one: Felt = fsub_(&Felt::zero(), &Felt::one());
     for i in build_and_bft.len()..(table.len as usize) {
+        write_pelt(&mut res_mary, &subj_pc1, &Row(i), &Col(ext_idx(INPUT_IDX)));
         write_pelt(&mut res_mary, &neg_one, &Row(i), &Col(ext_idx(INV_IDX)));
     }
 


### PR DESCRIPTION
The original jet was slightly incorrect by missing out on subj_pc1 being written in the padding, which would result in the final proof not being bit-perfect to what you'd get by interpreting the code.