### PR TITLE
Fix mining-key-adv configuration

### DIFF
--- a/crates/nockchain/src/config.rs
+++ b/crates/nockchain/src/config.rs
@@ -57,7 +57,6 @@ pub struct NockchainCli {
         help = "Advanced mining key configuration (mutually exclusive with --mining-pubkey). Format: share,m:key1,key2,key3",
         value_parser = value_parser!(MiningKeyConfig),
         num_args = 1..,
-        value_delimiter = ',',
     )]
     pub mining_key_adv: Option<Vec<MiningKeyConfig>>,
     #[arg(long, help = "Whether to run as fakenet", default_value_t = false)]


### PR DESCRIPTION
Advanced mining key itself contains commas, therefore Clap clashes with the argument. For setting up adv key config, you'll now need to supply `--mining-key-adv` multiple times.