### PR TITLE
Faster bpmul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,8 @@ dependencies = [
  "nockchain-libp2p-io",
  "nockvm",
  "nockvm_macros",
+ "num_cpus",
+ "rand 0.8.5",
  "tempfile",
  "termcolor",
  "tokio",

--- a/crates/zkvm-jetpack/src/form/belt.rs
+++ b/crates/zkvm-jetpack/src/form/belt.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use nockvm::noun::Noun;
 use num_traits::Pow;
@@ -71,6 +71,13 @@ impl Add for Belt {
         let a = self.0;
         let b = rhs.0;
         Belt(badd(a, b))
+    }
+}
+
+impl AddAssign for Belt {
+    #[inline(always)]
+    fn add_assign(&mut self, other: Self) {
+        self.0 = badd(self.0, other.0);
     }
 }
 


### PR DESCRIPTION
Conditional unrolling and blocked multiply increases bpmul performance (better instruction level parallelism). This PR also implements `AddAssign` for `Belt` to reduce overhead.

Equality was tested prior to opening this PR using an uncommitted benchmark.