### PR TITLE
CPU affinity setting, concurrent serf initialization, cancellation improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,6 +2030,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdt-cpus"
+version = "25.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a814bc54f3718130583f8a9a555b72c1d8b56937e01e9fa20f4d1d504b570645"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
+ "libc",
+ "log",
+ "mach-sys",
+ "nix 0.30.1",
+ "raw-cpuid",
+ "thiserror 2.0.12",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,6 +3483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach-sys"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48460c2e82a3a0de197152fdf8d2c2d5e43adc501501553e439bf2156e6f87c7"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,6 +3791,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3833,6 +3871,7 @@ dependencies = [
  "clap",
  "equix",
  "futures",
+ "gdt-cpus",
  "hoonc",
  "ibig",
  "kernels",
@@ -4967,7 +5006,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix",
+ "nix 0.26.4",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ tokio-rustls = "0.26.0"
 x509-parser = "0.16.0"
 rcgen = "0.13.0"
 webpki-roots = "0.26.0"
+gdt-cpus = "25"
 
 
 [profile.dev]

--- a/crates/nockapp/src/kernel/form.rs
+++ b/crates/nockapp/src/kernel/form.rs
@@ -492,9 +492,8 @@ fn serf_loop<C: SerfCheckpoint>(
                         .add_timing(&action_elapsed);
                 };
             }
-            SerfAction::CallFn { func, result } => {
+            SerfAction::CallFn { func } => {
                 func();
-                let _ = result.send(());
             }
         };
         let elapsed = start.elapsed();

--- a/crates/nockchain/Cargo.toml
+++ b/crates/nockchain/Cargo.toml
@@ -41,6 +41,7 @@ tracing.workspace = true
 tracing-test.workspace = true
 num_cpus = { workspace = true }
 rand = { workspace = true }
+gdt-cpus.workspace = true
 
 zkvm-jetpack.workspace = true
 

--- a/crates/nockchain/src/mining.rs
+++ b/crates/nockchain/src/mining.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
+use std::sync::Mutex as SyncMutex;
 
 use clap::{value_parser, Args};
+use gdt_cpus::CoreType;
 use kernels::miner::KERNEL;
 use nockapp::kernel::form::SerfThread;
 use nockapp::nockapp::driver::{IODriverFn, NockAppHandle, PokeResult};
@@ -13,10 +15,12 @@ use nockapp::utils::NOCK_STACK_SIZE_TINY;
 use nockapp::CrownError;
 use nockchain_libp2p_io::tip5_util::tip5_hash_to_base58;
 use nockvm::interpreter::NockCancelToken;
+use nockvm::jets::hot::HotEntry;
 use nockvm::noun::{Atom, D, NO, T, YES};
 use nockvm_macros::tas;
 use rand::Rng;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, watch, Mutex};
+use tokio::task::JoinHandle;
 use tracing::{debug, info, instrument, warn};
 use zkvm_jetpack::form::PRIME;
 use zkvm_jetpack::noun::noun_ext::NounExt as OtherNounExt;
@@ -79,6 +83,92 @@ impl FromStr for MiningKeyConfig {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum PinThreads {
+    // Pin threads in sequnece starting from starting core ID
+    Sequence { start_core_id: usize },
+    // Pin threads to exact logical core IDs
+    Exact { core_ids: Vec<usize> },
+    // Pin threads to performance cores
+    Performance,
+}
+
+impl FromStr for PinThreads {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once("=").unwrap_or((s, "")) {
+            ("sequence", v) => Ok(Self::Sequence {
+                start_core_id: v
+                    .parse()
+                    .map_err(|_| format!("Invalid starting core id: {v}"))?,
+            }),
+            ("exact", v) => {
+                let mut core_ids = vec![];
+                for (i, c) in v.split(",").enumerate() {
+                    core_ids.push(
+                        c.parse()
+                            .map_err(|_| format!("Invalid core ID at position {i}: {c}"))?,
+                    );
+                }
+                Ok(Self::Exact { core_ids })
+            }
+            ("performance", "") => Ok(Self::Performance),
+            _ => Err(
+                "Invalid format. Expected sequence=starting_core, exact=core1,core2,core3, or performance"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+impl PinThreads {
+    pub fn logical_core_ids(&self, num_threads: usize) -> Vec<usize> {
+        match self {
+            Self::Sequence { start_core_id } => (*start_core_id..).take(num_threads).collect(),
+            Self::Exact { core_ids } => {
+                assert_eq!(
+                    core_ids.len(),
+                    num_threads,
+                    "Number of exact core IDs does not match the number of miner threads"
+                );
+                core_ids.clone()
+            }
+            Self::Performance => {
+                let cpu_info = gdt_cpus::cpu_info().expect("Unable to query CPU info");
+                let is_hybrid = cpu_info.is_hybrid();
+
+                let mut cores = cpu_info
+                    .sockets
+                    .iter()
+                    .flat_map(|v| v.cores.iter())
+                    .filter(|v| !is_hybrid || v.core_type == CoreType::Performance)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                let mut core_ids = vec![];
+
+                // Fairly complicated loop to balance over different physical cores in SMT
+                // scenarios, and only pinning to the same hyperthread if we run out of physical
+                // cores.
+                'outer: loop {
+                    let start_len = core_ids.len();
+                    for c in &mut cores {
+                        if let Some(id) = c.logical_processor_ids.pop() {
+                            core_ids.push(id);
+                        }
+                        if core_ids.len() == num_threads {
+                            break 'outer;
+                        }
+                    }
+                    assert_ne!(start_len, core_ids.len(), "Number of performance cores on the machine insufficient for given miner threads");
+                }
+
+                core_ids
+            }
+        }
+    }
+}
+
 #[derive(Args, Clone, Debug, Default)]
 pub struct MiningConfig {
     #[arg(long, help = "Mine in-kernel", default_value = "false")]
@@ -97,6 +187,11 @@ pub struct MiningConfig {
         num_args = 1..,
     )]
     pub mining_key_adv: Option<Vec<MiningKeyConfig>>,
+    #[arg(
+        long,
+        help = "Pin miner threads to given CPU cores. Format: sequence=starting_core, exact=core1,core2,core3, or performance"
+    )]
+    pub pin_threads: Option<PinThreads>,
 }
 
 impl MiningConfig {
@@ -185,23 +280,37 @@ pub fn create_mining_driver(
             let num_threads = cfg.num_threads();
             info!("Starting mining driver with {} threads", num_threads);
 
-            let mut mining_attempts = tokio::task::JoinSet::<(
-                SerfThread<SaveableCheckpoint>,
-                u64,
-                Result<NounSlab, CrownError>,
-            )>::new();
+            let pin_threads = cfg
+                .pin_threads
+                .map(|v| v.logical_core_ids(num_threads as _));
+
             let hot_state = zkvm_jetpack::hot::produce_prover_hot_state();
             let test_jets_str = std::env::var("NOCK_TEST_JETS").unwrap_or_default();
             let test_jets = nockapp::kernel::boot::parse_test_jets(test_jets_str.as_str());
 
             let mining_data: Mutex<Option<MiningData>> = Mutex::new(None);
-            let mut cancel_tokens: Vec<NockCancelToken> = Vec::<NockCancelToken>::new();
+
+            let (mining_attempt_results, mut mining_attempts) = mpsc::channel(num_threads as usize);
+
+            let mut miners = tokio::task::JoinSet::new();
+            for i in 0..(num_threads as usize) {
+                let core_id = pin_threads.as_ref().map(|v| v[i]);
+                let miner_fut = MinerHandle::new(
+                    hot_state.clone(),
+                    test_jets.clone(),
+                    i,
+                    core_id,
+                    mining_attempt_results.clone(),
+                );
+                miners.spawn(miner_fut);
+            }
+            let miners = miners.join_all().await;
 
             loop {
                 tokio::select! {
-                        mining_result = mining_attempts.join_next(), if !mining_attempts.is_empty() => {
-                            let mining_result = mining_result.expect("Mining attempt failed");
-                            let (serf, id, slab_res) = mining_result.expect("Mining attempt result failed");
+                        mining_result = mining_attempts.recv() => {
+                            let (id, slab_res) = mining_result.expect("Mining attempt result failed");
+                            let miner = &miners[id];
                             let slab = slab_res.expect("Mining attempt result failed");
                             let result = unsafe { slab.root() };
                             // If the mining attempt was cancelled, the goof goes into poke_swap which returns
@@ -211,7 +320,7 @@ pub fn create_mining_driver(
                             if hed.is_atom() && hed.eq_bytes("poke") {
                                 //  mining attempt was cancelled. restart with current block header.
                                 debug!("mining attempt cancelled. restarting on new block header. thread={id}");
-                                start_mining_attempt(serf, mining_data.lock().await, &mut mining_attempts, None, id).await;
+                                start_mining_attempt(miner, mining_data.lock().await, None).await;
                             } else {
                                 //  there should only be one effect
                                 let effect = result.as_cell().expect("Expected result to be a cell").head();
@@ -219,17 +328,13 @@ pub fn create_mining_driver(
                                 if head.eq_bytes("mine-result") {
                                     if unsafe { res.raw_equals(&D(0)) } {
                                         // success
-                                        // poke main kernel with mined block and start a new attempt
+                                        // poke main kernel with mined block. Do not start a new attempt,
+                                        // because it will be invalid anyways.
                                         info!("Found block! thread={id}");
-                                        let [hash, poke] = tail.uncell().expect("Expected two elements in tail");
+                                        let [_, poke] = tail.uncell().expect("Expected two elements in tail");
                                         let mut poke_slab = NounSlab::new();
                                         poke_slab.copy_into(poke);
                                         handle.poke(MiningWire::Mined.to_wire(), poke_slab).await.expect("Could not poke nockchain with mined PoW");
-
-                                        // launch new attempt
-                                        let mut nonce_slab = NounSlab::new();
-                                        nonce_slab.copy_into(hash);
-                                        start_mining_attempt(serf, mining_data.lock().await, &mut mining_attempts, Some(nonce_slab), id).await;
                                     } else {
                                         // failure
                                         //  launch new attempt, using hash as new nonce
@@ -237,16 +342,23 @@ pub fn create_mining_driver(
                                         debug!("didn't find block, starting new attempt. thread={id}");
                                         let mut nonce_slab = NounSlab::new();
                                         nonce_slab.copy_into(tail);
-                                        start_mining_attempt(serf, mining_data.lock().await, &mut mining_attempts, Some(nonce_slab), id).await;
+                                        start_mining_attempt(miner, mining_data.lock().await, Some(nonce_slab)).await;
                                     }
                                 }
                             }
                         }
 
                     effect_res = handle.next_effect() => {
-                        let Ok(effect) = effect_res else {
-                            warn!("Error receiving effect in mining driver: {effect_res:?}");
-                            continue;
+                        let effect = match effect_res {
+                            Ok(effect) => effect,
+                            Err(NockAppError::BroadcastRecvClosedError) => {
+                                info!("Nockapp closing");
+                                break;
+                            }
+                            Err(e) => {
+                                warn!("Error receiving effect in mining driver: {e:?}");
+                                continue;
+                            }
                         };
                         let Ok(effect_cell) = (unsafe { effect.root().as_cell() }) else {
                             drop(effect);
@@ -283,39 +395,22 @@ pub fn create_mining_driver(
                                 pow_len: pow_len
                             });
 
-                            // Mining hasn't started yet, so start it
-                            if mining_attempts.is_empty() {
-                                info!("starting mining threads");
-                                for i in 0..num_threads {
-                                    let kernel = Vec::from(KERNEL);
-                                    let serf = SerfThread::<SaveableCheckpoint>::new(
-                                        kernel,
-                                        None,
-                                        hot_state.clone(),
-                                        NOCK_STACK_SIZE_TINY,
-                                        test_jets.clone(),
-                                        false,
-                                    )
-                                    .await
-                                    .expect("Could not load mining kernel");
-
-                                    cancel_tokens.push(serf.cancel_token.clone());
-
-                                    start_mining_attempt(serf, mining_data.lock().await, &mut mining_attempts, None, i).await;
-                                }
-                                info!("mining threads started with {} threads", num_threads);
-                            } else {
-                                // Mining is already running so cancel all the running attemps
-                                // which are mining on the old block.
-                                debug!("restarting mining attempts with new block header.");
-                                for token in &cancel_tokens {
-                                    token.cancel();
-                                }
+                            // Cancel any existing mining attempts, and create new attempts
+                            for m in &miners {
+                                start_mining_attempt(m, mining_data.lock().await, None).await;
                             }
                         }
                     }
                 }
             }
+
+            debug!("Stopping miner threads");
+            core::mem::drop(mining_attempts);
+            for m in miners {
+                m.finish().await;
+            }
+
+            Ok(())
         })
     })
 }
@@ -411,15 +506,9 @@ async fn enable_mining(handle: &NockAppHandle, enable: bool) -> Result<PokeResul
 }
 
 async fn start_mining_attempt(
-    serf: SerfThread<SaveableCheckpoint>,
+    miner: &MinerHandle,
     mining_data: tokio::sync::MutexGuard<'_, Option<MiningData>>,
-    mining_attempts: &mut tokio::task::JoinSet<(
-        SerfThread<SaveableCheckpoint>,
-        u64,
-        Result<NounSlab, CrownError>,
-    )>,
     nonce: Option<NounSlab>,
-    id: u64,
 ) {
     let nonce = nonce.unwrap_or_else(|| {
         let mut rng = rand::thread_rng();
@@ -441,14 +530,115 @@ async fn start_mining_attempt(
         .expect("Mining data should already be initialized");
     debug!(
         "starting mining attempt on thread {:?} on header {:?}with nonce: {:?}",
-        id,
+        miner.id,
         tip5_hash_to_base58(*unsafe { mining_data_ref.block_header.root() })
             .expect("Failed to convert block header to Base58"),
         tip5_hash_to_base58(*unsafe { nonce.root() }).expect("Failed to convert nonce to Base58"),
     );
     let poke_slab = create_poke(mining_data_ref, &nonce);
-    mining_attempts.spawn(async move {
-        let result = serf.poke(MiningWire::Candidate.to_wire(), poke_slab).await;
-        (serf, id, result)
-    });
+    miner.send_poke(poke_slab);
+}
+
+struct Miner {
+    serf: SerfThread<SaveableCheckpoint>,
+    id: usize,
+    results: mpsc::Sender<(usize, Result<NounSlab, CrownError>)>,
+    reqs: watch::Receiver<SyncMutex<Option<NounSlab>>>,
+}
+
+impl Miner {
+    pub async fn run(mut self) {
+        while self.reqs.changed().await.is_ok() {
+            let Some(poke_slab) = ({
+                let mtx = self.reqs.borrow_and_update();
+                let mut guard = mtx.lock().expect("Poisoned lock");
+                guard.take()
+            }) else {
+                continue;
+            };
+
+            let result = self
+                .serf
+                .poke(MiningWire::Candidate.to_wire(), poke_slab)
+                .await;
+
+            if self.results.send((self.id, result)).await.is_err() {
+                break;
+            }
+        }
+    }
+}
+
+struct MinerHandle {
+    reqs: watch::Sender<SyncMutex<Option<NounSlab>>>,
+    cancellation: NockCancelToken,
+    miner_loop: JoinHandle<()>,
+    id: usize,
+}
+
+impl MinerHandle {
+    pub async fn new(
+        hot_state: Vec<HotEntry>,
+        test_jets: Vec<NounSlab>,
+        id: usize,
+        thread_pin: Option<usize>,
+        results: mpsc::Sender<(usize, Result<NounSlab, CrownError>)>,
+    ) -> Self {
+        let kernel = Vec::from(KERNEL);
+        let serf = SerfThread::<SaveableCheckpoint>::new(
+            kernel,
+            None,
+            hot_state,
+            NOCK_STACK_SIZE_TINY,
+            test_jets,
+            Default::default(),
+        )
+        .await
+        .expect("Could not load mining kernel");
+
+        let cancellation = serf.cancel_token.clone();
+
+        if let Some(core_id) = thread_pin {
+            serf.call_fn(move || gdt_cpus::pin_thread_to_core(core_id))
+                .await
+                .expect("Could not invoke core pinning")
+                .expect("Could not pin the miner thread");
+        }
+
+        let (tx, rx) = watch::channel(SyncMutex::new(None));
+
+        let miner = Miner {
+            serf,
+            id,
+            results,
+            reqs: rx,
+        };
+
+        let miner_loop = tokio::spawn(miner.run());
+
+        Self {
+            reqs: tx,
+            cancellation,
+            miner_loop,
+            id,
+        }
+    }
+
+    pub fn send_poke(&self, poke_slab: NounSlab) {
+        self.reqs.send_modify(|v| {
+            let mut guard = v.lock().expect("Poisoned lock");
+            *guard = Some(poke_slab);
+            // Cancel while holding the guard to prevent the miner from racing to a stale request.
+            self.cancel_current_poke();
+        });
+    }
+
+    pub fn cancel_current_poke(&self) {
+        self.cancellation.cancel();
+    }
+
+    pub async fn finish(self) {
+        self.cancel_current_poke();
+        let _ = self.miner_loop.await;
+    }
 }


### PR DESCRIPTION
- Allow setting CPU affinity to a sequence of logical core IDs, a fixed set of logical core IDs, or first num-threads of performance cores (by wrapping around to hyperthreads, if not enough cores).
- Move out miner config into mining module to simplify extensibility and call flow.
- Initialize serfs concurrently, which helps on high-core-count machines.
- Rework miner loop so that its control flow is easier to reason about (no longer passing serfs back and forth).
- Filter out duplicate mine pokes.