### PR TITLE
zkvm-jetpack: Add Melt type

### DIFF
--- a/crates/zkvm-jetpack/src/form/belt.rs
+++ b/crates/zkvm-jetpack/src/form/belt.rs
@@ -4,6 +4,7 @@ use nockvm::noun::Noun;
 use num_traits::Pow;
 use tracing::debug;
 
+use super::Melt;
 use crate::based;
 use crate::form::math::base::*;
 use crate::form::poly::Belt;
@@ -60,6 +61,13 @@ impl Belt {
     #[inline(always)]
     pub fn inv(&self) -> Self {
         Belt(binv(self.0))
+    }
+
+    pub fn from_melt_vec(mut v: Vec<Melt>) -> Vec<Self> {
+        const _: [(); core::mem::size_of::<Melt>()] = [(); core::mem::size_of::<Belt>()];
+        v.iter_mut().for_each(|v| *v = Melt(Belt::from(*v).0));
+        // SAFETY: Melt and Belt have the same size and bit representation
+        unsafe { core::mem::transmute(v) }
     }
 }
 

--- a/crates/zkvm-jetpack/src/form/math/base.rs
+++ b/crates/zkvm-jetpack/src/form/math/base.rs
@@ -11,7 +11,7 @@ pub enum FieldError {
     OrderedRootError,
 }
 
-pub fn based_check(a: u64) -> bool {
+pub const fn based_check(a: u64) -> bool {
     a < PRIME
 }
 

--- a/crates/zkvm-jetpack/src/form/math/mod.rs
+++ b/crates/zkvm-jetpack/src/form/math/mod.rs
@@ -4,6 +4,7 @@ pub mod fext;
 pub mod fpoly;
 pub mod gen_trace;
 pub mod mary;
+pub mod mont;
 pub mod prover;
 pub mod tip5;
 

--- a/crates/zkvm-jetpack/src/form/math/mont.rs
+++ b/crates/zkvm-jetpack/src/form/math/mont.rs
@@ -1,0 +1,29 @@
+use super::tip5::R2;
+use crate::based;
+use crate::form::tip5::RP;
+
+pub const fn montify(x: u64) -> u64 {
+    // transform to Montgomery space, i.e. compute x•r = xr mod p
+    montiply(x, R2)
+}
+
+pub const fn montiply(a: u64, b: u64) -> u64 {
+    // computes a*b = (abr^{-1} mod p)
+    based!(a);
+    based!(b);
+    mont_reduction((a as u128) * (b as u128))
+}
+
+pub const fn mont_reduction(x: u128) -> u64 {
+    // mont-reduction: computes x•r^{-1} = (xr^{-1} mod p).
+    assert!(x < RP);
+
+    let x1 = x as u64;
+    let x2 = (x >> 64) as u64;
+
+    let (a, e) = x1.overflowing_add(x1 << 32);
+    let b = a.wrapping_sub(a >> 32).wrapping_sub(e as u64);
+
+    let (r, c) = x2.overflowing_sub(b);
+    r.wrapping_sub((u32::MAX as u64) * c as u64)
+}

--- a/crates/zkvm-jetpack/src/form/melt.rs
+++ b/crates/zkvm-jetpack/src/form/melt.rs
@@ -1,0 +1,135 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use nockvm::noun::Noun;
+use num_traits::Pow;
+
+use crate::form::math::base::*;
+use crate::form::math::mont::*;
+use crate::form::poly::{Belt, Melt};
+
+impl Melt {
+    pub fn inv(self) -> Self {
+        self.pow(PRIME - 2)
+    }
+
+    pub const fn from_u64(v: u64) -> Self {
+        Self(montify(v))
+    }
+
+    pub const fn pow(self, exp: u64) -> Self {
+        let mut acc = Melt::from_u64(1).0;
+        let bit_length = u64::BITS - exp.leading_zeros();
+        let mut i = 0;
+        while i < bit_length {
+            acc = montiply(acc, acc);
+            if exp & (1 << (bit_length - 1 - i)) != 0 {
+                acc = montiply(acc, self.0);
+            }
+            i += 1;
+        }
+
+        Melt(acc)
+    }
+
+    pub fn from_belt_vec(mut v: Vec<Belt>) -> Vec<Self> {
+        const _: [(); core::mem::size_of::<Melt>()] = [(); core::mem::size_of::<Belt>()];
+        v.iter_mut().for_each(|v| *v = Belt(Melt::from(*v).0));
+        // SAFETY: Melt and Belt have the same size and bit representation
+        unsafe { core::mem::transmute(v) }
+    }
+}
+
+impl From<Melt> for Belt {
+    #[inline(always)]
+    fn from(value: Melt) -> Self {
+        Belt(mont_reduction(value.0 as _))
+    }
+}
+
+impl From<Belt> for Melt {
+    #[inline(always)]
+    fn from(value: Belt) -> Self {
+        Melt::from_u64(value.0)
+    }
+}
+
+impl Add for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        let a = self.0;
+        let b = rhs.0;
+        Melt(badd(a, b))
+    }
+}
+
+impl Sub for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(bsub(self.0, rhs.0))
+    }
+}
+
+impl Neg for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    fn neg(self) -> Self::Output {
+        Self(bneg(self.0))
+    }
+}
+
+impl Mul for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        let a = self.0;
+        let b = rhs.0;
+        Melt(montiply(a, b))
+    }
+}
+
+impl Pow<u64> for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, exp: u64) -> Self::Output {
+        Melt::pow(self, exp)
+    }
+}
+
+impl Pow<usize> for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    fn pow(self, rhs: usize) -> Self::Output {
+        self.pow(rhs as u64).into()
+    }
+}
+
+impl Div for Melt {
+    type Output = Self;
+
+    #[inline(always)]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn div(self, rhs: Self) -> Self::Output {
+        rhs.inv() * self
+    }
+}
+
+impl TryFrom<Noun> for Melt {
+    type Error = ();
+
+    #[inline(always)]
+    fn try_from(n: Noun) -> std::result::Result<Self, Self::Error> {
+        if !n.is_atom() {
+            Err(())
+        } else {
+            Belt::try_from(&n.as_atom()?.as_u64()?).map(|v| v.into())
+        }
+    }
+}

--- a/crates/zkvm-jetpack/src/form/mod.rs
+++ b/crates/zkvm-jetpack/src/form/mod.rs
@@ -4,8 +4,10 @@ pub mod felt;
 pub mod mary;
 pub mod math;
 pub mod mega;
+pub mod melt;
 pub mod poly;
 
 pub use math::*;
 pub use mega::*;
+pub use melt::*;
 pub use poly::*;

--- a/crates/zkvm-jetpack/src/form/poly.rs
+++ b/crates/zkvm-jetpack/src/form/poly.rs
@@ -1,10 +1,15 @@
 #![allow(clippy::len_without_is_empty)]
 
+use std::fmt::Debug;
 use std::slice::Iter;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 pub struct Belt(pub u64);
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct Melt(pub u64);
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -52,6 +57,25 @@ impl Element for Belt {
     #[inline(always)]
     fn one() -> Self {
         Belt::one()
+    }
+}
+
+impl Element for Melt {
+    #[inline(always)]
+    fn is_zero(&self) -> bool {
+        self.0 == Melt::zero().0
+    }
+    #[inline(always)]
+    fn zero() -> Self {
+        Belt::zero().into()
+    }
+    #[inline(always)]
+    fn len() -> usize {
+        1
+    }
+    #[inline(always)]
+    fn one() -> Self {
+        Belt::one().into()
     }
 }
 
@@ -233,6 +257,18 @@ impl<'a> From<&'a Felt> for BPolySlice<'a> {
 impl<'a> From<&'a BPolySliceMut<'_>> for BPolySlice<'a> {
     fn from(p: &'a BPolySliceMut) -> Self {
         Self(p.0)
+    }
+}
+
+impl From<PolyVec<Melt>> for PolyVec<Belt> {
+    fn from(v: PolyVec<Melt>) -> Self {
+        PolyVec(Belt::from_melt_vec(v.0))
+    }
+}
+
+impl From<PolyVec<Belt>> for PolyVec<Melt> {
+    fn from(v: PolyVec<Belt>) -> Self {
+        PolyVec(Melt::from_belt_vec(v.0))
     }
 }
 

--- a/crates/zkvm-jetpack/src/jets/mary_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/mary_jets.rs
@@ -372,7 +372,7 @@ fn snag_as_digest(stack: &mut NockStack, m_noun: Noun, i: usize) -> Result<Noun,
     digest[3] = cut(stack, 6, 3, 1, buf)?.as_atom()?.as_u64()?;
     digest[4] = cut(stack, 6, 4, 1, buf)?.as_atom()?.as_u64()?;
 
-    Ok(digest_to_noundigest(stack, digest))
+    Ok(digest_to_noundigest(stack, digest.map(Belt)))
 }
 
 pub fn mary_to_list_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {

--- a/crates/zkvm-jetpack/src/jets/tip5_jets.rs
+++ b/crates/zkvm-jetpack/src/jets/tip5_jets.rs
@@ -8,8 +8,9 @@ use nockvm::noun::{Atom, Noun, D, T};
 use nockvm_macros::tas;
 
 use crate::based;
+use crate::form::math::mont::mont_reduction;
 use crate::form::math::tip5::*;
-use crate::form::{Belt, Poly};
+use crate::form::{Belt, Melt, Poly};
 use crate::hand::structs::HoonList;
 use crate::jets::bp_jets::bpoly_to_list;
 use crate::jets::mary_jets::{change_step, get_mary_fields};
@@ -18,21 +19,21 @@ use crate::jets::utils::jet_err;
 use crate::noun::noun_ext::NounExt;
 use crate::utils::{
     belt_as_noun, bitslice_to_u128, fits_in_u128, hoon_list_to_vecbelt, hoon_list_to_vecnoun,
-    vec_to_hoon_list, vecnoun_to_hoon_list,
+    melt_as_noun, vec_to_hoon_list, vecnoun_to_hoon_list,
 };
 
-pub fn hoon_list_to_sponge(list: Noun) -> Result<[u64; STATE_SIZE], JetErr> {
+pub fn hoon_list_to_sponge(list: Noun) -> Result<Sponge, JetErr> {
     if list.is_atom() {
         return jet_err();
     }
 
-    let mut sponge = [0; STATE_SIZE];
+    let mut sponge = [Melt(0); STATE_SIZE];
     let mut current = list;
     let mut i = 0;
 
     while current.is_cell() {
         let cell = current.as_cell()?;
-        sponge[i] = cell.head().as_atom()?.as_u64()?;
+        sponge[i] = Melt(cell.head().as_atom()?.as_u64()?);
         current = cell.tail();
         i = i + 1;
     }
@@ -50,7 +51,7 @@ pub fn permutation_jet(context: &mut Context, subject: Noun) -> Result<Noun, Jet
     let mut sponge = hoon_list_to_sponge(sample)?;
     permute(&mut sponge);
 
-    let new_sponge = vec_to_hoon_list(stack, &sponge);
+    let new_sponge = vec_to_hoon_list(stack, &sponge.map(|v| v.0));
 
     Ok(new_sponge)
 }
@@ -75,24 +76,13 @@ pub fn tip5_pad_vecbelt(input_vec: &mut Vec<Belt>, r: usize) {
     }
 }
 
-// monitify vecbelt (bring into montgomery space)
-pub fn tip5_montify_vecbelt(input_vec: &mut Vec<Belt>) {
-    for i in 0..input_vec.len() {
-        input_vec[i] = montify(input_vec[i]);
-    }
-}
-
 // calc digest
-pub fn tip5_calc_digest(sponge: &[u64; 16]) -> [u64; 5] {
-    let mut digest = [0u64; DIGEST_LENGTH];
-    for i in 0..DIGEST_LENGTH {
-        digest[i] = mont_reduction(sponge[i] as u128).0;
-    }
-    digest
+pub fn tip5_calc_digest(sponge: &Sponge) -> Digest<Melt> {
+    sponge[..DIGEST_LENGTH].try_into().unwrap()
 }
 
 // absorb complete input
-pub fn tip5_absorb_input(input_vec: &mut Vec<Belt>, mut sponge: &mut [u64; 16], q: usize) {
+pub fn tip5_absorb_input(input_vec: &mut Vec<Belt>, mut sponge: &mut Sponge, q: usize) {
     let mut cnt_q = q;
     let mut input_to_absorb = input_vec.as_slice();
     loop {
@@ -108,11 +98,11 @@ pub fn tip5_absorb_input(input_vec: &mut Vec<Belt>, mut sponge: &mut [u64; 16], 
 }
 
 // absorb one part of input (size RATE)
-pub fn tip5_absorb_rate(sponge: &mut [u64; 16], input: &[Belt]) {
+pub fn tip5_absorb_rate(sponge: &mut Sponge, input: &[Belt]) {
     assert_eq!(input.len(), RATE);
 
     for copy_pos in 0..RATE {
-        sponge[copy_pos] = input[copy_pos].0;
+        sponge[copy_pos] = input[copy_pos].into();
     }
 
     permute(sponge);
@@ -121,14 +111,14 @@ pub fn tip5_absorb_rate(sponge: &mut [u64; 16], input: &[Belt]) {
 pub fn hash_varlen_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
     let stack = &mut context.stack;
     let input = slot(subject, 6)?;
-    let mut input_vec = hoon_list_to_vecbelt(input)?;
+    let input_vec = hoon_list_to_vecbelt(input)?;
 
-    let digest = hash_varlen(&mut input_vec);
+    let digest = hash_varlen(input_vec);
 
-    Ok(vec_to_hoon_list(stack, &digest))
+    Ok(vec_to_hoon_list(stack, &digest.map(|v| v.0)))
 }
 
-fn hash_varlen(mut input_vec: &mut Vec<Belt>) -> [u64; 5] {
+fn hash_varlen(mut input_vec: Vec<Belt>) -> Digest {
     let mut sponge = create_init_sponge_variable();
 
     // assert that input is made of base field elements
@@ -138,25 +128,23 @@ fn hash_varlen(mut input_vec: &mut Vec<Belt>) -> [u64; 5] {
     let (q, r) = tip5_calc_q_r(&input_vec);
     tip5_pad_vecbelt(&mut input_vec, r);
 
-    // bring input into montgomery space
-    tip5_montify_vecbelt(&mut input_vec);
-
     // process input in batches of size RATE
     tip5_absorb_input(&mut input_vec, &mut sponge, q);
 
     // calc digest
     let digest = tip5_calc_digest(&sponge);
-    digest
+    digest.map(Into::into)
 }
 
-pub fn create_init_sponge_variable() -> [u64; STATE_SIZE] {
-    [0u64; STATE_SIZE]
+pub fn create_init_sponge_variable() -> Sponge {
+    [Melt(0); STATE_SIZE]
 }
-pub fn create_init_sponge_fixed() -> [u64; STATE_SIZE] {
+pub fn create_init_sponge_fixed() -> Sponge {
     [
         0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 4294967295u64, 4294967295u64,
         4294967295u64, 4294967295u64, 4294967295u64, 4294967295u64,
     ]
+    .map(Melt)
 }
 
 pub fn montify_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
@@ -164,28 +152,16 @@ pub fn montify_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr>
     let sam = slot(subject, 6)?;
     let x = Belt(sam.as_atom()?.as_u64()?);
 
-    let res = montify(x);
+    let res = Melt::from(x);
 
-    Ok(belt_as_noun(stack, res))
-}
-
-fn montify(x: Belt) -> Belt {
-    // transform to Montgomery space, i.e. compute x•r = xr mod p
-    montiply(x, Belt(R2))
+    Ok(melt_as_noun(stack, res))
 }
 
 pub fn montiply_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
     let sam = slot(subject, 6)?;
-    let a = Belt(sam.as_cell()?.head().as_atom()?.as_u64()?);
-    let b = Belt(sam.as_cell()?.tail().as_atom()?.as_u64()?);
-    Ok(belt_as_noun(&mut context.stack, montiply(a, b)))
-}
-
-fn montiply(a: Belt, b: Belt) -> Belt {
-    // computes a*b = (abr^{-1} mod p)
-    based!(a.0);
-    based!(b.0);
-    mont_reduction((a.0 as u128) * (b.0 as u128))
+    let a = Melt(sam.as_cell()?.head().as_atom()?.as_u64()?);
+    let b = Melt(sam.as_cell()?.tail().as_atom()?.as_u64()?);
+    Ok(melt_as_noun(&mut context.stack, a * b))
 }
 
 pub fn mont_reduction_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
@@ -208,32 +184,10 @@ pub fn mont_reduction_jet(context: &mut Context, subject: Noun) -> Result<Noun, 
         x_atom.as_u64()? as u128
     };
 
-    Ok(belt_as_noun(&mut context.stack, mont_reduction(x_u128)))
-}
-
-pub fn mont_reduction(x_u128: u128) -> Belt {
-    // mont-reduction: computes x•r^{-1} = (xr^{-1} mod p).
-    assert!(x_u128 < RP);
-
-    const R_MOD_P1: u128 = (R_MOD_P + 1) as u128; // 4.294.967.296
-    const RX: u128 = R; // 18.446.744.073.709.551.616
-    const PX: u128 = P as u128; // 0xffffffff00000001
-
-    let x1_u128_div = x_u128 / R_MOD_P1;
-    let x1_u128 = x1_u128_div % R_MOD_P1;
-    let x2_u128 = x_u128 / RX;
-    let x0_u128 = x_u128 % R_MOD_P1;
-    let c_u128 = (x0_u128 + x1_u128) * R_MOD_P1;
-    let f_u128 = c_u128 / RX;
-    let d_u128 = c_u128 - (x1_u128 + (f_u128 * PX));
-
-    let res = if x2_u128 >= d_u128 {
-        x2_u128 - d_u128
-    } else {
-        (x2_u128 + PX) - d_u128
-    };
-
-    Belt(res as u64)
+    Ok(belt_as_noun(
+        &mut context.stack,
+        Belt(mont_reduction(x_u128)),
+    ))
 }
 
 pub fn hash_belts_list_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
@@ -243,17 +197,17 @@ pub fn hash_belts_list_jet(context: &mut Context, subject: Noun) -> Result<Noun,
 }
 
 pub fn hash_belts_list(stack: &mut NockStack, input: Noun) -> Result<Noun, JetErr> {
-    let mut input_vec = hoon_list_to_vecbelt(input)?;
-    let digest = hash_varlen(&mut input_vec);
+    let input_vec = hoon_list_to_vecbelt(input)?;
+    let digest = hash_varlen(input_vec);
     Ok(digest_to_noundigest(stack, digest))
 }
 
-pub fn digest_to_noundigest(stack: &mut NockStack, digest: [u64; 5]) -> Noun {
-    let n0 = belt_as_noun(stack, Belt(digest[0]));
-    let n1 = belt_as_noun(stack, Belt(digest[1]));
-    let n2 = belt_as_noun(stack, Belt(digest[2]));
-    let n3 = belt_as_noun(stack, Belt(digest[3]));
-    let n4 = belt_as_noun(stack, Belt(digest[4]));
+pub fn digest_to_noundigest(stack: &mut NockStack, digest: Digest) -> Noun {
+    let n0 = belt_as_noun(stack, digest[0]);
+    let n1 = belt_as_noun(stack, digest[1]);
+    let n2 = belt_as_noun(stack, digest[2]);
+    let n3 = belt_as_noun(stack, digest[3]);
+    let n4 = belt_as_noun(stack, digest[4]);
 
     T(stack, &[n0, n1, n2, n3, n4])
 }
@@ -266,18 +220,15 @@ pub fn hash_10_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr>
 
     let digest = hash_10(&mut input_vec);
 
-    Ok(vec_to_hoon_list(stack, &digest))
+    Ok(vec_to_hoon_list(stack, &digest.map(|v| v.0)))
 }
 
-fn hash_10(mut input_vec: &mut Vec<Belt>) -> [u64; 5] {
+fn hash_10(input_vec: &mut Vec<Belt>) -> Digest {
     // check input
     let (q, r) = tip5_calc_q_r(&input_vec);
     assert_eq!(q, 1);
     assert_eq!(r, 0);
     assert_all_based(&input_vec);
-
-    // bring input into montgomery space
-    tip5_montify_vecbelt(&mut input_vec);
 
     // create init sponge (%fixed)
     let mut sponge = create_init_sponge_fixed();
@@ -287,7 +238,7 @@ fn hash_10(mut input_vec: &mut Vec<Belt>) -> [u64; 5] {
     tip5_absorb_rate(&mut sponge, input_vec.as_slice());
 
     //  calc digest
-    tip5_calc_digest(&sponge)
+    tip5_calc_digest(&sponge).map(Into::into)
 }
 
 pub fn hash_pairs_jet(context: &mut Context, subject: Noun) -> Result<Noun, JetErr> {
@@ -314,7 +265,7 @@ pub fn hash_pairs(stack: &mut NockStack, lis_noun: Noun) -> Result<Noun, JetErr>
             let mut pair = b0;
             pair.append(&mut b1);
             let digest = hash_10(&mut pair);
-            let digest_noun = vec_to_hoon_list(stack, &digest);
+            let digest_noun = vec_to_hoon_list(stack, &digest.map(|v| v.0));
             res.push(digest_noun);
         }
     }

--- a/crates/zkvm-jetpack/src/utils.rs
+++ b/crates/zkvm-jetpack/src/utils.rs
@@ -6,7 +6,7 @@ use nockvm::mem::NockStack;
 use nockvm::noun::{Atom, IndirectAtom, Noun, D, DIRECT_MAX, NONE, T};
 pub use tracing::{debug, trace};
 
-use crate::form::Belt;
+use crate::form::{Belt, Melt};
 
 // tests whether a felt atom has the leading 1. we cannot actually test
 // Felt, because it doesn't include the leading 1.
@@ -85,6 +85,12 @@ pub fn fits_in_u128(bits: &BitSlice<u64, Lsb0>) -> bool {
 // convert a belt to noun
 #[inline(always)]
 pub fn belt_as_noun(stack: &mut NockStack, res: Belt) -> Noun {
+    u128_as_noun(stack, res.0 as u128)
+}
+
+// convert a belt to noun
+#[inline(always)]
+pub fn melt_as_noun(stack: &mut NockStack, res: Melt) -> Noun {
     u128_as_noun(stack, res.0 as u128)
 }
 


### PR DESCRIPTION
This PR cleans up type hygiene by introducing a `Melt` type. This allows to easily distinguish between montgomery and non-montgomery integers, and cleanly track their type changes.

`Sponge` is now a typedef, as well as `Digest` so that you don't have to manually specify the types there.