### PR TITLE
Add import key from seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,8 @@ dependencies = [
  "nockchain-libp2p-io",
  "nockvm",
  "nockvm_macros",
+ "num_cpus",
+ "rand 0.8.5",
  "tempfile",
  "termcolor",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3887,13 +3887,17 @@ dependencies = [
  "crossterm 0.28.1",
  "either",
  "getrandom 0.2.16",
+ "hmac",
  "image",
  "kernels",
  "nockapp",
  "nockvm",
+ "nockvm_crypto",
  "nockvm_macros",
+ "pbkdf2",
  "qrcode",
  "ratatui",
+ "sha2",
  "tempfile",
  "termimad",
  "thiserror 2.0.12",
@@ -4275,6 +4279,15 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "pem"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ aes-siv = { version = "0.7.0", default-features = false }
 # sha
 sha1 = { version = "0.10.6", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
+hmac = { version = "0.12", default-features = false }
+pbkdf2 = { version = "0.12", default-features = false }
 
 # nockapp-specific workspace dependencies
 anyhow = "1.0"

--- a/crates/nockchain-wallet/Cargo.toml
+++ b/crates/nockchain-wallet/Cargo.toml
@@ -8,14 +8,18 @@ kernels = { workspace = true, features = ["wallet"] }
 nockapp = { workspace = true }
 nockvm = { workspace = true }
 nockvm_macros = { workspace = true }
+nockvm_crypto = { workspace = true, features = ["sha"] }
 
 bardecoder = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 crossterm.workspace = true
 either.workspace = true
 getrandom.workspace = true
+hmac.workspace = true
 image = { workspace = true }
+pbkdf2.workspace = true
 qrcode = { workspace = true }
+sha2.workspace = true
 ratatui.workspace = true
 tempfile.workspace = true
 termimad.workspace = true


### PR DESCRIPTION
Added support for importing keys using seed phrase functionality to the crates/nockchain-wallet crate. The implementation follows the following:
- The implementation leverages the existing BIP39 functionality in the Hoon kernel ([bip39.hoon](https://github.com/zorp-corp/nockchain/blob/master/hoon/common/bip39.hoon))
- It reuses the gen-master-privkey kernel command, which already handles seed phrase to master key conversion
- The implementation follows the same patterns as other wallet commands for consistency