### PR TITLE
Removed unnecessary `-p`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ To check your wallet balance:
 
 ```bash
 # List all notes by pubkey
-nockchain-wallet list-notes-by-pubkey -p <your-pubkey>
+nockchain-wallet list-notes-by-pubkey <your-pubkey>
 ```
 
 ### How do I configure logging levels?


### PR DESCRIPTION
The proposed command for checking balance included a `-p` which is not required for running that command.
```
chrishobcroft@nockedup:~$ nockchain-wallet list-notes-by-pubkey --help
List notes by public key

Usage: nockchain-wallet list-notes-by-pubkey [OPTIONS] [PUBKEY]

Arguments:
  [PUBKEY]  Optional public key to filter notes

Options:
      --client <CLIENT>
          Which client to connect to: public or private [default: public] [possible values: public, private]
      --public-grpc-server-addr <PUBLIC_GRPC_SERVER_ADDR>
          Address of the public server (host[:port] or URI) [default: https://nockchain-api.zorp.io]
      --include-watch-only
          Include watch-only pubkeys when synchronizing wallet balance
  -h, --help
          Print help
```