### PR TITLE
Add jojo repl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,6 +2325,7 @@ dependencies = [
  "mio 1.1.1",
  "parking_lot",
  "rustix 0.38.44",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -3165,6 +3198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3247,6 +3291,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -4412,6 +4468,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "jojo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitvec",
+ "clap",
+ "either",
+ "equix",
+ "flume",
+ "futures",
+ "hoonc",
+ "kernels-open-jojo",
+ "nockapp",
+ "nockvm",
+ "nockvm_macros",
+ "rayon",
+ "reedline",
+ "tempfile",
+ "termcolor",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-test",
+ "vergen",
+ "zkvm-jetpack",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,6 +4555,10 @@ version = "0.1.0"
 
 [[package]]
 name = "kernels-open-dumb"
+version = "0.1.0"
+
+[[package]]
+name = "kernels-open-jojo"
 version = "0.1.0"
 
 [[package]]
@@ -5271,6 +5359,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5907,6 +6004,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7189,6 +7295,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "reedline"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5cdfab7494d13ebfb6ce64828648518205d3ce8541ef1f94a27887f29d2d50b"
+dependencies = [
+ "chrono",
+ "crossterm 0.28.1",
+ "fd-lock",
+ "itertools 0.13.0",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7736,6 +7862,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "semver-parser"
@@ -8089,6 +8219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8136,6 +8275,15 @@ name = "strict"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -8258,6 +8406,20 @@ dependencies = [
  "ntapi",
  "once_cell",
  "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -8462,7 +8624,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -9203,6 +9367,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "8.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "cfg-if",
+ "regex",
+ "rustc_version 0.4.1",
+ "rustversion",
+ "sysinfo 0.30.13",
+ "time",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9223,6 +9403,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9502,6 +9691,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -9529,6 +9728,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,6 +4481,8 @@ dependencies = [
  "hoonc",
  "kernels-open-jojo",
  "nockapp",
+ "nockapp-grpc",
+ "nockapp-grpc-proto",
  "nockvm",
  "nockvm_macros",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 resolver = "2"
 
 [workspace]
-members = ["crates/bridge", "crates/equix-latency", "crates/habit", "crates/hoon", "crates/hoonc", "crates/kernels/bridge", "crates/kernels/dumb", "crates/kernels/miner", "crates/kernels/nockchain-peek", "crates/kernels/wallet", "crates/nockapp", "crates/nockapp-grpc", "crates/nockapp-grpc-proto", "crates/nockchain", "crates/nockchain-api", "crates/nockchain-explorer-tui", "crates/nockchain-libp2p-io", "crates/nockchain-math", "crates/nockchain-peek", "crates/nockchain-types", "crates/nockchain-wallet", "crates/nockup", "crates/nockvm/rust/ibig", "crates/nockvm/rust/murmur3", "crates/nockvm/rust/nockvm", "crates/nockvm/rust/nockvm_macros", "crates/noun-serde", "crates/noun-serde-derive", "crates/raw-tx-checker", "crates/wallet-tx-builder", "crates/zkvm-jetpack"]
+members = ["crates/bridge", "crates/equix-latency", "crates/habit", "crates/hoon", "crates/hoonc", "crates/kernels/bridge", "crates/kernels/dumb", "crates/kernels/miner", "crates/kernels/nockchain-peek", "crates/kernels/wallet", "crates/nockapp", "crates/nockapp-grpc", "crates/nockapp-grpc-proto", "crates/nockchain", "crates/nockchain-api", "crates/nockchain-explorer-tui", "crates/nockchain-libp2p-io", "crates/nockchain-math", "crates/nockchain-peek", "crates/nockchain-types", "crates/nockchain-wallet", "crates/nockup", "crates/nockvm/rust/ibig", "crates/nockvm/rust/murmur3", "crates/nockvm/rust/nockvm", "crates/nockvm/rust/nockvm_macros", "crates/noun-serde", "crates/noun-serde-derive", "crates/raw-tx-checker", "crates/wallet-tx-builder", "crates/zkvm-jetpack", "crates/jojo", "crates/kernels/jojo"]
 
 [workspace.package]
 version = "0.1.0"
@@ -48,6 +48,7 @@ ed25519-dalek = { version = "2.1.0", default-features = false }
 either = "1.9.0"
 equix = "0.2.2"
 flate2 = "1.1.5"
+flume = "0.11"
 fs_extra = "1.3"
 futures = "0.3.31"
 gdt-cpus = "25.5.0"
@@ -103,6 +104,7 @@ rand = { version = "0.9.2", features = ["std"] }
 ratatui = "0.29.0"
 rayon = "1.8.0"
 rcgen = "0.14.3"
+reedline = "0.40"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "http2",
@@ -202,6 +204,9 @@ path = "crates/kernels/bridge"
 
 [workspace.dependencies.kernels-open-dumb]
 path = "crates/kernels/dumb"
+
+[workspace.dependencies.kernels-open-jojo]
+path = "crates/kernels/jojo"
 
 [workspace.dependencies.kernels-open-miner]
 path = "crates/kernels/miner"

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build-trivial: ensure-dirs
 	echo '%trivial' > hoon/trivial.hoon
 	hoonc --arbitrary hoon/trivial.hoon
 
-HOON_TARGETS=assets/dumb.jam assets/wal.jam assets/miner.jam assets/peek.jam assets/bridge.jam
+HOON_TARGETS=assets/dumb.jam assets/wal.jam assets/miner.jam assets/peek.jam assets/bridge.jam assets/jojo.jam
 
 .PHONY: nuke-hoonc-data
 nuke-hoonc-data:
@@ -162,3 +162,9 @@ assets/bridge.jam: ensure-dirs hoon/apps/bridge/bridge.hoon $(HOON_SRCS)
 	rm -f assets/bridge.jam
 	hoonc hoon/apps/bridge/bridge.hoon hoon
 	mv out.jam assets/bridge.jam
+
+## Build jojo.jam
+assets/jojo.jam: update-hoonc hoon/apps/jojo/jojo.hoon $(HOON_SRCS)
+	$(call show_env_vars)
+	RUST_LOG=trace hoonc hoon/apps/jojo/jojo.hoon hoon
+	mv out.jam assets/jojo.jam

--- a/crates/jojo/Cargo.toml
+++ b/crates/jojo/Cargo.toml
@@ -11,6 +11,8 @@ kernels-open-jojo.workspace = true
 nockapp.workspace = true
 nockvm.workspace = true
 nockvm_macros.workspace = true
+nockapp-grpc = { workspace = true, features = ["client"] }
+nockapp-grpc-proto = { workspace = true, features = ["client"] }
 bitvec.workspace = true
 either.workspace = true
 

--- a/crates/jojo/Cargo.toml
+++ b/crates/jojo/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "jojo"
+build = "build.rs"
+publish = false
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+hoonc.workspace = true
+kernels-open-jojo.workspace = true
+nockapp.workspace = true
+nockvm.workspace = true
+nockvm_macros.workspace = true
+bitvec.workspace = true
+either.workspace = true
+
+clap.workspace = true
+equix.workspace = true
+futures.workspace = true
+tempfile = { workspace = true }
+termcolor.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-test.workspace = true
+tokio-stream.workspace = true
+reedline.workspace = true
+anyhow.workspace = true
+flume.workspace = true
+rayon.workspace = true
+
+zkvm-jetpack.workspace = true
+
+[build-dependencies]
+vergen = { workspace = true, features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+    "si",
+] }

--- a/crates/jojo/build.rs
+++ b/crates/jojo/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    // List of Bazel built-in stamping variables to embed
+    let bazel_vars = [
+        "BUILD_EMBED_LABEL", "BUILD_HOST", "BUILD_USER", "BUILD_TIMESTAMP",
+        "FORMATTED_DATE",
+        // You can add more built-in variables or your own STABLE_ variables as needed
+    ];
+
+    // Set cargo:rustc-env for each variable that exists
+    for var in bazel_vars {
+        let value = std::env::var(var).unwrap_or_else(|_| "unknown".to_string());
+        println!("cargo:rustc-env={var}={value}");
+    }
+}

--- a/crates/jojo/src/main.rs
+++ b/crates/jojo/src/main.rs
@@ -1,0 +1,105 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use flume::Receiver;
+use futures::{Stream, StreamExt};
+use kernels_open_jojo::KERNEL;
+use nockapp::kernel::boot::{self, Cli};
+use nockapp::kernel::form::Kernel;
+use nockapp::noun::slab::NounSlab;
+use nockapp::save::SaveableCheckpoint;
+use nockapp::wire::Wire;
+use zkvm_jetpack::hot::produce_prover_hot_state;
+
+mod parse;
+mod shell;
+use shell::Shell;
+
+struct SendSlab(NounSlab);
+
+unsafe impl Send for SendSlab {}
+unsafe impl Sync for SendSlab {}
+
+pub enum JojoWire {
+    Run,
+}
+
+impl JojoWire {
+    pub fn verb(&self) -> &'static str {
+        match self {
+            JojoWire::Run => "run",
+        }
+    }
+}
+
+impl Wire for JojoWire {
+    const VERSION: u64 = 1;
+    const SOURCE: &'static str = "jojo";
+
+    fn to_wire(&self) -> nockapp::wire::WireRepr {
+        let tags = vec![self.verb().into()];
+        nockapp::wire::WireRepr::new(JojoWire::SOURCE, JojoWire::VERSION, tags)
+    }
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Mode {
+    Shell,
+}
+
+/// Command line arguments
+#[derive(Parser, Debug, Clone)]
+#[command(name = "jojo")]
+pub struct JojoCli {
+    #[command(flatten)]
+    pub nockapp_cli: Cli,
+    #[command(subcommand)]
+    pub mode: Mode,
+}
+
+async fn run_kernel(
+    pokes: impl Stream<Item = SendSlab> + Send + 'static,
+    cli: Cli,
+) -> Receiver<SendSlab> {
+    let hot_state = produce_prover_hot_state();
+
+    let kernel = Kernel::<SaveableCheckpoint>::load_with_hot_state(
+        KERNEL,
+        None,
+        &hot_state,
+        vec![],
+        cli.trace_opts.into(),
+    )
+    .await
+    .expect("Could not load jojo kernel");
+
+    let (tx, rx) = flume::bounded(0);
+
+    let task = async move {
+        let mut pokes = core::pin::pin!(pokes);
+        while let Some(slab) = pokes.next().await {
+            let effects = kernel
+                .poke(JojoWire::Run.to_wire(), slab.0)
+                .await
+                .expect("Could not poke jojo kernel with slab");
+
+            if tx.send_async(SendSlab(effects)).await.is_err() {
+                break;
+            }
+        }
+    };
+
+    tokio::spawn(task);
+
+    rx
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    nockvm::check_endian();
+    let cli = JojoCli::parse();
+    boot::init_default_tracing(&cli.nockapp_cli);
+
+    match cli.mode {
+        Mode::Shell => Shell::default().run(cli.nockapp_cli).await,
+    }
+}

--- a/crates/jojo/src/main.rs
+++ b/crates/jojo/src/main.rs
@@ -12,7 +12,7 @@ use zkvm_jetpack::hot::produce_prover_hot_state;
 
 mod parse;
 mod shell;
-use shell::Shell;
+use shell::{Shell, ShellArgs};
 
 struct SendSlab(NounSlab);
 
@@ -43,7 +43,7 @@ impl Wire for JojoWire {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Mode {
-    Shell,
+    Shell(ShellArgs),
 }
 
 /// Command line arguments
@@ -100,6 +100,6 @@ async fn main() -> Result<()> {
     boot::init_default_tracing(&cli.nockapp_cli);
 
     match cli.mode {
-        Mode::Shell => Shell::default().run(cli.nockapp_cli).await,
+        Mode::Shell(a) => Shell::default().run(cli.nockapp_cli, a).await,
     }
 }

--- a/crates/jojo/src/parse.rs
+++ b/crates/jojo/src/parse.rs
@@ -1,0 +1,149 @@
+#[derive(Debug, PartialEq)]
+pub enum Node {
+    Leaf(String),
+    Branch(Vec<Node>),
+}
+
+impl Node {
+    pub fn fold<T, E, C>(
+        self,
+        c: &mut C,
+        fold_leaf: &mut impl FnMut(String, &mut C) -> Result<T, E>,
+        fold_branch: &mut impl FnMut(Vec<T>, &mut C) -> Result<T, E>,
+    ) -> Result<T, E> {
+        match self {
+            Self::Leaf(l) => fold_leaf(l, c),
+            Self::Branch(b) => {
+                let b = b
+                    .into_iter()
+                    .map(|v| v.fold(c, fold_leaf, fold_branch))
+                    .collect::<Result<Vec<T>, E>>()?;
+                fold_branch(b, c)
+            }
+        }
+    }
+}
+
+struct Parser {
+    chars: Vec<char>,
+    pos: usize,
+}
+
+impl Parser {
+    pub fn new(input: &str) -> Self {
+        Parser {
+            chars: input.chars().collect::<Vec<_>>(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.chars.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) {
+        self.pos += 1;
+    }
+
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(c) if c.is_whitespace()) {
+            self.bump();
+        }
+    }
+
+    fn parse_leaf(&mut self) -> Node {
+        let start = self.pos;
+        while matches!(self.peek(), Some(c) if !c.is_whitespace() && c != ']' && c != '[') {
+            self.bump();
+        }
+        let s: String = self.chars[start..self.pos].iter().collect();
+        Node::Leaf(s)
+    }
+
+    fn parse_branch(&mut self) -> Option<Node> {
+        // consume '['
+        assert_eq!(self.peek(), Some('['));
+        self.bump();
+        let mut children = Vec::new();
+        loop {
+            self.skip_ws();
+            match self.peek() {
+                Some(']') => {
+                    self.bump();
+                    break;
+                }
+                Some('[') => children.push(self.parse_branch()?),
+                Some(_) => children.push(self.parse_leaf()),
+                None => return None,
+            }
+        }
+        Some(Node::Branch(children))
+    }
+
+    fn parse(&mut self) -> Option<Node> {
+        self.skip_ws();
+        match self.peek() {
+            Some('[') => self.parse_branch(),
+            Some(_) => Some(self.parse_leaf()),
+            None => None,
+        }
+    }
+}
+
+pub fn parse_tree(input: &str) -> Option<(Node, &str)> {
+    let mut parser = Parser::new(input);
+    let parsed = parser.parse()?;
+    Some((parsed, input.split_at(parser.pos).1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple() {
+        assert_eq!(parse_tree("a").unwrap(), (Node::Leaf("a".into()), ""));
+        assert_eq!(
+            parse_tree("[a b c]").unwrap(),
+            (
+                Node::Branch(vec![
+                    Node::Leaf("a".into()),
+                    Node::Leaf("b".into()),
+                    Node::Leaf("c".into()),
+                ]),
+                ""
+            )
+        );
+        assert_eq!(
+            parse_tree("[[a b] c] asd").unwrap(),
+            (
+                Node::Branch(vec![
+                    Node::Branch(vec![Node::Leaf("a".into()), Node::Leaf("b".into())]),
+                    Node::Leaf("c".into()),
+                ]),
+                " asd"
+            )
+        );
+        assert_eq!(
+            parse_tree("[[a b c] d]").unwrap().0,
+            Node::Branch(vec![
+                Node::Branch(vec![
+                    Node::Leaf("a".into()),
+                    Node::Leaf("b".into()),
+                    Node::Leaf("c".into()),
+                ]),
+                Node::Leaf("d".into()),
+            ])
+        );
+        assert_eq!(
+            parse_tree("[[a [b c]] d]").unwrap().0,
+            Node::Branch(vec![
+                Node::Branch(vec![
+                    Node::Leaf("a".into()),
+                    Node::Branch(vec![Node::Leaf("b".into()), Node::Leaf("c".into()),]),
+                ]),
+                Node::Leaf("d".into()),
+            ])
+        );
+    }
+}

--- a/crates/jojo/src/shell.rs
+++ b/crates/jojo/src/shell.rs
@@ -1,0 +1,459 @@
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use either::Either;
+use flume::Sender;
+use nockapp::kernel::boot::Cli;
+use nockapp::noun::slab::NounSlab;
+use nockapp::Bytes;
+use nockvm::jets::util::slot;
+use nockvm::jets::JetErr;
+use nockvm::noun::*;
+use nockvm_macros::tas;
+use reedline::{DefaultPrompt, DefaultPromptSegment, FileBackedHistory, Reedline, Signal};
+
+use crate::parse::{parse_tree, Node};
+use crate::{run_kernel, SendSlab};
+
+fn input_func(out: Sender<Option<String>>) -> Result<()> {
+    loop {
+        if out.send(None).is_err() {
+            break;
+        }
+
+        let history = Box::new(FileBackedHistory::with_file(50, "jojo.hist".into())?);
+        let mut rl = Reedline::create().with_history(history);
+
+        let prompt = DefaultPrompt {
+            left_prompt: DefaultPromptSegment::Basic("~nockvm:jojo".to_string()),
+            right_prompt: DefaultPromptSegment::Empty,
+        };
+
+        match rl.read_line(&prompt)? {
+            Signal::Success(line) => {
+                if out.send(Some(line)).is_err() {
+                    break;
+                }
+                let _ = rl.sync_history();
+            }
+            Signal::CtrlD | Signal::CtrlC => break,
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct ShellCommand {
+    hoon: Option<String>,
+    in_sample: Option<Node>,
+    in_subject: Option<Node>,
+    out_sample: Option<String>,
+    jam_out: Option<String>,
+    cue_inp: Option<(String, usize)>,
+    list_vars: bool,
+    debug_print: bool,
+}
+
+impl ShellCommand {
+    fn parse(mut line: &str) -> Result<Self> {
+        let mut in_sample = None;
+        let mut in_subject = None;
+        let mut out_sample = None;
+        let mut jam_out = None;
+        let mut cue_inp = None;
+        let mut list_vars = false;
+        let mut file_hoon = false;
+        let mut debug_print = false;
+
+        let hoon = if line.starts_with('/') {
+            line = line.split_once('/').unwrap().1;
+
+            loop {
+                let (mut cmd, mut rest) = line.split_once(' ').unwrap_or((line, ""));
+
+                fn parse_vars<'a>(rest: &mut &'a str) -> Result<(Option<Node>, &'a str)> {
+                    let Some((tree, tail)) = parse_tree(rest) else {
+                        return Err(anyhow!("Malformed command: {rest}"));
+                    };
+
+                    *rest = tail.trim_ascii_start();
+
+                    Ok((Some(tree), rest))
+                }
+
+                match cmd {
+                    "?" | "help" => {
+                        return Err(anyhow!(
+                            r"Usage:
+
+/?, /help - display this message.
+/. sam func - evaluate `func` with the given sample `sam`. Given sample can be constructed from variable assignments (using /.), and can be a cell, e.g. [a b].
+// sam path - load `path` and evaluate its hoon with sample `sam`. Given sample can be constructed from variable assignments.
+/: sub hoon - evaluate `hoon` with subject `sub`. Subject can be constructed from variable assignments.
+/= var hoon - evaluage `hoon` and assign output to `var`.
+/+ v s hoon - evaluate `hoon` on subject `s`, and assign output to `v`. Subject can be constructed from variable assignments.
+/| v s func - evaluate `func` with the given sample `s` and assign output to `v`.
+/p sam      - print given sample `sam`. Note: if single variable is provided, it is pretty-printed, but mutliple variables are printed as raw nouns.
+/D sam      - (fast) debug print given sample `sam`. This will print the noun on rust side.
+/v          - list defined variables.
+/c var path - cue a jamfile at `path` and assign it to `var`.
+/s var path - cue a subject jamfile at `path`, take the sample at axis 6, and assign it to `var`.
+/j sam path - jam the given sample `sam` and write it to `path`.
+hoon - evaluate `hoon` and print the result out to screen.
+                            "
+                        ))
+                    }
+                    "." => (in_sample, line) = parse_vars(&mut rest)?,
+                    "/" => {
+                        (in_sample, line) = {
+                            file_hoon = true;
+                            parse_vars(&mut rest)?
+                        }
+                    }
+                    ":" => (in_subject, line) = parse_vars(&mut rest)?,
+                    "=" => {
+                        (cmd, line) = rest.split_once(' ').unwrap_or((rest, ""));
+                        if cmd.is_empty() {
+                            return Err(anyhow!("Sample is not specified"));
+                        }
+                        out_sample = Some(cmd.to_string());
+                    }
+                    "+" => {
+                        (cmd, rest) = rest.split_once(' ').unwrap_or((rest, ""));
+                        if cmd.is_empty() {
+                            return Err(anyhow!("Sample is not specified"));
+                        }
+                        out_sample = Some(cmd.to_string());
+                        (in_subject, line) = parse_vars(&mut rest)?;
+                    }
+                    "|" => {
+                        (cmd, rest) = rest.split_once(' ').unwrap_or((rest, ""));
+                        if cmd.is_empty() {
+                            return Err(anyhow!("Sample is not specified"));
+                        }
+                        out_sample = Some(cmd.to_string());
+                        (in_sample, line) = parse_vars(&mut rest)?;
+                    }
+                    "p" => {
+                        (in_sample, _) = parse_vars(&mut rest)?;
+                        break None;
+                    }
+                    "D" => {
+                        (in_sample, _) = parse_vars(&mut rest)?;
+                        debug_print = true;
+                        break None;
+                    }
+                    "v" => {
+                        list_vars = true;
+                        break None;
+                    }
+                    "c" => {
+                        let (var, path) = rest
+                            .split_once(' ')
+                            .ok_or_else(|| anyhow!("Unable to cue: invalid input"))?;
+                        out_sample = Some(var.to_string());
+                        cue_inp = Some((path.to_string(), 1));
+                    }
+                    "s" => {
+                        let (var, path) = rest
+                            .split_once(' ')
+                            .ok_or_else(|| anyhow!("Unable to cue: invalid input"))?;
+                        out_sample = Some(var.to_string());
+                        cue_inp = Some((path.to_string(), 6));
+                    }
+                    "j" => {
+                        (in_sample, line) = parse_vars(&mut rest)?;
+                        jam_out = Some(line.to_string());
+                        break None;
+                    }
+                    _ => return Err(anyhow!("Invalid command! (use /help for usage)")),
+                }
+
+                break Some(line.trim_ascii_start());
+            }
+        } else {
+            Some(line)
+        };
+
+        let hoon = hoon
+            .map(|hoon| {
+                if file_hoon {
+                    std::fs::read_to_string(hoon)
+                } else if !hoon.starts_with(char::is_alphabetic) || !hoon.contains(' ') {
+                    Ok(hoon.to_string())
+                } else {
+                    Ok(format!("({hoon})"))
+                }
+            })
+            .transpose()?;
+
+        Ok(Self {
+            hoon,
+            in_sample,
+            in_subject,
+            out_sample,
+            jam_out,
+            cue_inp,
+            list_vars,
+            debug_print,
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct Shell {
+    samples: HashMap<String, (bool, NounSlab)>,
+    save_state: Option<String>,
+}
+
+enum Command {
+    Eval(NounSlab),
+    Jam(Bytes, String),
+    Cue(String, usize),
+    ListVars(Vec<String>),
+    DebugPrint(Noun),
+}
+
+impl Shell {
+    fn next_command(&mut self, line: &str) -> Result<Command> {
+        let ShellCommand {
+            hoon,
+            in_sample,
+            in_subject,
+            out_sample,
+            jam_out,
+            cue_inp,
+            list_vars,
+            debug_print,
+        } = ShellCommand::parse(line)?;
+
+        let prt = D(out_sample.is_some() as u64);
+        self.save_state = out_sample;
+
+        let mut slab: NounSlab = NounSlab::new();
+
+        let mut vases = [None, None];
+
+        for (vas, sam) in vases.iter_mut().zip([in_sample, in_subject]) {
+            if let Some(tree) = sam {
+                let pull_noun = |slab: &mut NounSlab, sample: String| {
+                    self.samples
+                        .get(&sample)
+                        .map(|(vased, v)| (vased, unsafe { *v.root() }))
+                        .map(|(vased, v)| {
+                            (vased, unsafe {
+                                slab.copy_into(v);
+                                *slab.root()
+                            })
+                        })
+                        .ok_or_else(|| anyhow!("{sample} is undefined"))
+                };
+
+                if let Node::Leaf(sample) = &tree {
+                    let (vased, mut noun) = pull_noun(&mut slab, sample.clone())?;
+                    if !vased {
+                        noun = T(&mut slab, &[D(tas!(b"noun")), noun]);
+                    }
+                    *vas = Some(noun);
+                } else {
+                    let noun = tree.fold(
+                        &mut slab,
+                        &mut |sample: String, slab| {
+                            pull_noun(slab, sample).map(|(vased, v)| {
+                                if *vased {
+                                    slot(v, 3).unwrap()
+                                } else {
+                                    v
+                                }
+                            })
+                        },
+                        &mut |nouns: Vec<Noun>, slab| Ok(T(slab, &nouns[..])),
+                    )?;
+                    *vas = Some(T(&mut slab, &[D(tas!(b"noun")), noun]));
+                }
+            }
+        }
+
+        let [vased_sample, vased_subject] = vases;
+
+        let vased_subject = vased_subject
+            .map(|v| T(&mut slab, &[D(0), v]))
+            .unwrap_or(D(0));
+
+        if let Some(jam) = jam_out {
+            let sam = vased_sample
+                .and_then(|v| slot(v, 3).ok())
+                .ok_or_else(|| anyhow!("Cannot jam without sample (impossible)"))?;
+            let slab: NounSlab = NounSlab::from(sam);
+            let bytes = slab.jam();
+            return Ok(Command::Jam(bytes, jam));
+        } else if let Some((cue, axis)) = cue_inp {
+            return Ok(Command::Cue(cue, axis));
+        } else if list_vars {
+            return Ok(Command::ListVars(self.samples.keys().cloned().collect()));
+        } else if debug_print {
+            let sam = vased_sample.unwrap();
+            return Ok(Command::DebugPrint(slot(sam, 3).unwrap()));
+        }
+
+        let hoon = hoon.as_deref().map(|v| unsafe {
+            IndirectAtom::new_raw_bytes(&mut slab, v.len(), v.as_ptr()).as_noun()
+        });
+
+        let poke = match (hoon, vased_sample) {
+            (Some(hoon), Some(sam)) => {
+                let sam = slot(sam, 3).unwrap();
+                slab.copy_into(sam);
+                let sam = unsafe { *slab.root() };
+                T(&mut slab, &[D(tas!(b"sam")), prt, hoon, vased_subject, sam])
+            }
+            (Some(hoon), None) => T(&mut slab, &[D(tas!(b"raw")), prt, hoon, vased_subject]),
+            (None, Some(sam)) => {
+                slab.copy_into(sam);
+                let sam = unsafe { *slab.root() };
+                T(&mut slab, &[D(tas!(b"prt")), prt, sam])
+            }
+            _ => return Err(anyhow!("Invalid command")),
+        };
+
+        slab.set_root(poke);
+
+        Ok(Command::Eval(slab))
+    }
+
+    /// Returns if should print
+    fn process_out(&mut self, vased: bool, out: Noun) -> bool {
+        if let Some(sam) = self.save_state.take() {
+            self.samples.insert(sam, (vased, out.into()));
+            false
+        } else {
+            true
+        }
+    }
+
+    pub async fn run(mut self, cli: Cli) -> Result<()> {
+        let (tx, rx) = flume::bounded(0);
+        let effects = run_kernel(rx.into_stream(), cli).await;
+
+        // Intentionally rendezvous!
+        let (lines_out, lines) = flume::bounded(0);
+
+        let task = tokio::task::spawn_blocking(move || input_func(lines_out));
+
+        while let Ok(line) = lines.recv_async().await {
+            let Some(line) = line else { continue };
+
+            if line.is_empty() {
+                continue;
+            }
+
+            let command = match self.next_command(&line) {
+                Ok(s) => s,
+                Err(e) => {
+                    println!("{e}");
+                    continue;
+                }
+            };
+
+            match command {
+                Command::Jam(bytes, path) => {
+                    if let Err(e) = tokio::fs::write(&path, bytes).await {
+                        println!("Unable to save jam to {path}: {e}");
+                    }
+                }
+                Command::Cue(path, axis) => {
+                    if let Err(e) = async {
+                        let mut slab: NounSlab = NounSlab::new();
+                        let bytes = tokio::fs::read(&path).await?;
+                        let noun = slab.cue_into(bytes.into())?;
+                        if let Ok(noun) = slot(noun, axis as u64) {
+                            self.process_out(false, noun);
+                        } else {
+                            println!("Unable to cue - invalid axis");
+                        }
+                        anyhow::Ok(())
+                    }
+                    .await
+                    {
+                        println!("Unable to cue at path {path}: {e}");
+                    }
+                }
+                Command::ListVars(vars) => {
+                    println!("Defined variables:");
+                    for v in vars {
+                        println!("{v}");
+                    }
+                }
+                Command::DebugPrint(noun) => {
+                    if let Ok(c) = noun.as_cell() {
+                        println!("Cell: {:?}", FullDebugCell(&c));
+                    } else {
+                        println!("Noun: {noun:?}");
+                    }
+                }
+                Command::Eval(slab) => {
+                    tx.send_async(SendSlab(slab)).await?;
+                    let slab = effects.recv_async().await?.0;
+                    let effect = unsafe { slab.root() };
+
+                    let handle_eval =
+                        |shell: &mut Shell, effect: Noun| -> core::result::Result<(), JetErr> {
+                            let Ok(cell) = effect.as_cell() else {
+                                println!("Unrecognized result {effect:?}");
+                                return Ok(());
+                            };
+
+                            match cell.head().as_either_atom_cell() {
+                                Either::Left(a) => {
+                                    match std::str::from_utf8(a.as_ne_bytes())
+                                        .map(|v| v.trim_end_matches('\0'))
+                                    {
+                                        Ok("poke") => {
+                                            println!("Error running command");
+                                        }
+                                        _ => println!("Unrecognized result"),
+                                    }
+                                }
+                                Either::Right(cell) => {
+                                    let res = cell.tail();
+                                    match cell
+                                        .head()
+                                        .as_atom()
+                                        .map(|a| a.to_le_bytes())
+                                        .as_deref()
+                                        .ok()
+                                        .and_then(|v| std::str::from_utf8(v).ok())
+                                        .map(|v| v.trim_end_matches('\0'))
+                                    {
+                                        Some("jojo") => {
+                                            let vase = slot(res, 2).unwrap();
+                                            if shell.process_out(true, vase) {
+                                                if let Ok(c) = slot(res, 3).unwrap().as_cell() {
+                                                    let pretty = c.tail().as_atom().unwrap();
+                                                    let pretty = pretty.as_ne_bytes();
+                                                    let pretty = std::str::from_utf8(pretty)
+                                                        .unwrap()
+                                                        .trim_end_matches('\0');
+                                                    println!("{pretty}");
+                                                }
+                                            }
+                                        }
+                                        v => {
+                                            println!("Unrecognized result {v:?}");
+                                        }
+                                    }
+                                }
+                            }
+
+                            Ok(())
+                        };
+
+                    handle_eval(&mut self, *effect).unwrap();
+                }
+            }
+        }
+
+        task.await?
+    }
+}

--- a/crates/jojo/src/shell.rs
+++ b/crates/jojo/src/shell.rs
@@ -6,6 +6,9 @@ use flume::Sender;
 use nockapp::kernel::boot::Cli;
 use nockapp::noun::slab::NounSlab;
 use nockapp::Bytes;
+use nockapp_grpc::pb::common::v1::Wire;
+use nockapp_grpc::private_nockapp::PrivateNockAppGrpcClient;
+use nockvm::jets::cold::Nounable;
 use nockvm::jets::util::slot;
 use nockvm::jets::JetErr;
 use nockvm::noun::*;
@@ -14,6 +17,15 @@ use reedline::{DefaultPrompt, DefaultPromptSegment, FileBackedHistory, Reedline,
 
 use crate::parse::{parse_tree, Node};
 use crate::{run_kernel, SendSlab};
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct ShellArgs {
+    #[arg(
+        long,
+        help = "gRPC server address to connect to for /< and /> commands."
+    )]
+    pub grpc_addr: Option<String>,
+}
 
 fn input_func(out: Sender<Option<String>>) -> Result<()> {
     loop {
@@ -49,6 +61,8 @@ struct ShellCommand {
     in_sample: Option<Node>,
     in_subject: Option<Node>,
     out_sample: Option<String>,
+    peek_path: Option<Vec<String>>,
+    grpc_remote: bool,
     jam_out: Option<String>,
     cue_inp: Option<(String, usize)>,
     list_vars: bool,
@@ -62,6 +76,8 @@ impl ShellCommand {
         let mut out_sample = None;
         let mut jam_out = None;
         let mut cue_inp = None;
+        let mut peek_path = None;
+        let mut grpc_remote = false;
         let mut list_vars = false;
         let mut file_hoon = false;
         let mut debug_print = false;
@@ -88,10 +104,10 @@ impl ShellCommand {
                             r"Usage:
 
 /?, /help - display this message.
-/. sam func - evaluate `func` with the given sample `sam`. Given sample can be constructed from variable assignments (using /.), and can be a cell, e.g. [a b].
+/. sam func - evaluate `func` with the given sample `sam`. Given sample can be constructed from variable assignments (using /=), and can be a cell, e.g. [a b].
 // sam path - load `path` and evaluate its hoon with sample `sam`. Given sample can be constructed from variable assignments.
 /: sub hoon - evaluate `hoon` with subject `sub`. Subject can be constructed from variable assignments.
-/= var hoon - evaluage `hoon` and assign output to `var`.
+/= var hoon - evaluate `hoon` and assign output to `var`.
 /+ v s hoon - evaluate `hoon` on subject `s`, and assign output to `v`. Subject can be constructed from variable assignments.
 /| v s func - evaluate `func` with the given sample `s` and assign output to `v`.
 /p sam      - print given sample `sam`. Note: if single variable is provided, it is pretty-printed, but mutliple variables are printed as raw nouns.
@@ -100,7 +116,12 @@ impl ShellCommand {
 /c var path - cue a jamfile at `path` and assign it to `var`.
 /s var path - cue a subject jamfile at `path`, take the sample at axis 6, and assign it to `var`.
 /j sam path - jam the given sample `sam` and write it to `path`.
+/( var path - gRPC peek at given `path` and store it at `var`.
+/< var s p  - gRPC peek with given sample `s` (attom sequence) appended to path `p`, and store it at `var`.
+/> var sam  - gRPC poke with given sample `sam`, store the success at `var`.
 hoon - evaluate `hoon` and print the result out to screen.
+
+var = _ is a special case for 'do not store, print'
                             "
                         ))
                     }
@@ -167,6 +188,33 @@ hoon - evaluate `hoon` and print the result out to screen.
                         jam_out = Some(line.to_string());
                         break None;
                     }
+                    "(" => {
+                        let (var, path) = rest
+                            .split_once(' ')
+                            .ok_or_else(|| anyhow!("Unable to peek: invalid input"))?;
+                        out_sample = Some(var.to_string());
+                        peek_path =
+                            Some(path.split("/").map(|v| v.to_string()).collect::<Vec<_>>());
+                        grpc_remote = true;
+                    }
+                    "<" => {
+                        (cmd, rest) = rest
+                            .split_once(' ')
+                            .ok_or_else(|| anyhow!("Unable to peek: invalid input"))?;
+                        out_sample = Some(cmd.to_string());
+                        (in_sample, cmd) = parse_vars(&mut rest)?;
+                        peek_path = Some(cmd.split("/").map(|v| v.to_string()).collect::<Vec<_>>());
+                        grpc_remote = true;
+                    }
+                    ">" => {
+                        (cmd, rest) = rest.split_once(' ').unwrap_or((rest, ""));
+                        if cmd.is_empty() {
+                            return Err(anyhow!("Sample is not specified"));
+                        }
+                        out_sample = Some(cmd.to_string());
+                        (in_sample, line) = parse_vars(&mut rest)?;
+                        grpc_remote = true;
+                    }
                     _ => return Err(anyhow!("Invalid command! (use /help for usage)")),
                 }
 
@@ -188,11 +236,18 @@ hoon - evaluate `hoon` and print the result out to screen.
             })
             .transpose()?;
 
+        // Special-case this
+        if out_sample.as_deref() == Some("_") {
+            out_sample = None;
+        }
+
         Ok(Self {
             hoon,
             in_sample,
             in_subject,
             out_sample,
+            peek_path,
+            grpc_remote,
             jam_out,
             cue_inp,
             list_vars,
@@ -213,6 +268,8 @@ enum Command {
     Cue(String, usize),
     ListVars(Vec<String>),
     DebugPrint(Noun),
+    Peek(NounSlab),
+    Poke(NounSlab),
 }
 
 impl Shell {
@@ -222,6 +279,8 @@ impl Shell {
             in_sample,
             in_subject,
             out_sample,
+            peek_path,
+            grpc_remote,
             jam_out,
             cue_inp,
             list_vars,
@@ -295,6 +354,49 @@ impl Shell {
         } else if debug_print {
             let sam = vased_sample.unwrap();
             return Ok(Command::DebugPrint(slot(sam, 3).unwrap()));
+        } else if grpc_remote {
+            if let Some(peek_path) = peek_path {
+                let mut path_slab: NounSlab = NounSlab::new();
+
+                let mut path_segs = peek_path
+                    .iter()
+                    .skip_while(|v| v.is_empty())
+                    .take_while(|v| !v.is_empty())
+                    .map(|v| v.into_noun(&mut path_slab))
+                    .collect::<Vec<_>>();
+
+                if let Some(mut sam) = vased_sample.and_then(|v| slot(v, 3).ok()) {
+                    while let Ok(c) = sam.as_cell() {
+                        let Ok(a) = c.head().as_atom() else {
+                            return Err(anyhow!("Supplied sample is not pure atoms"));
+                        };
+                        path_segs.push(path_slab.copy_into(a.as_noun()));
+                        sam = c.tail();
+                    }
+                    let Ok(a) = sam.as_atom() else {
+                        return Err(anyhow!("Supplied sample is not pure atoms"));
+                    };
+                    path_segs.push(path_slab.copy_into(a.as_noun()));
+                }
+
+                path_segs.push(D(0));
+
+                let path_noun = match &path_segs[..] {
+                    [v] => *v,
+                    [] => return Err(anyhow!("Invalid path given")),
+                    v => T(&mut path_slab, v),
+                };
+
+                path_slab.copy_into(path_noun);
+
+                return Ok(Command::Peek(path_slab));
+            } else {
+                let sam = vased_sample
+                    .and_then(|v| slot(v, 3).ok())
+                    .ok_or_else(|| anyhow!("Cannot jam without sample (impossible)"))?;
+                let slab: NounSlab = NounSlab::from(sam);
+                return Ok(Command::Poke(slab));
+            }
         }
 
         let hoon = hoon.as_deref().map(|v| unsafe {
@@ -317,7 +419,7 @@ impl Shell {
             _ => return Err(anyhow!("Invalid command")),
         };
 
-        slab.set_root(poke);
+        slab.copy_into(poke);
 
         Ok(Command::Eval(slab))
     }
@@ -332,9 +434,19 @@ impl Shell {
         }
     }
 
-    pub async fn run(mut self, cli: Cli) -> Result<()> {
+    pub async fn run(mut self, cli: Cli, a: ShellArgs) -> Result<()> {
         let (tx, rx) = flume::bounded(0);
         let effects = run_kernel(rx.into_stream(), cli).await;
+
+        let mut grpc_client = if let Some(address) = a.grpc_addr {
+            let client = PrivateNockAppGrpcClient::connect(address)
+                .await
+                .map_err(|e| anyhow!("gRPC connect failure: {e}"))?;
+
+            Some(client)
+        } else {
+            None
+        };
 
         // Intentionally rendezvous!
         let (lines_out, lines) = flume::bounded(0);
@@ -390,6 +502,58 @@ impl Shell {
                         println!("Cell: {:?}", FullDebugCell(&c));
                     } else {
                         println!("Noun: {noun:?}");
+                    }
+                }
+                Command::Peek(slab) => {
+                    let Some(client) = &mut grpc_client else {
+                        return Err(anyhow!(
+                            "gRPC client not connected. Rerun jojo with --help for more."
+                        ));
+                    };
+
+                    let slab = slab.jam();
+
+                    let jam_bytes = client
+                        .peek(0, slab.into())
+                        .await
+                        .map_err(|e| anyhow!("gRPC peek failed: {e}"))?;
+
+                    let mut slab: NounSlab = NounSlab::new();
+                    let noun = slab.cue_into(Bytes::from(jam_bytes))?;
+
+                    if self.process_out(false, noun) {
+                        if let Ok(c) = noun.as_cell() {
+                            println!("Cell: {:?}", FullDebugCell(&c));
+                        } else {
+                            println!("Noun: {noun:?}");
+                        }
+                    }
+                }
+                Command::Poke(slab) => {
+                    let Some(client) = &mut grpc_client else {
+                        return Err(anyhow!(
+                            "gRPC client not connected. Rerun jojo with --help for more."
+                        ));
+                    };
+
+                    let slab = slab.jam();
+
+                    // TODO: enable custom wires
+                    let wire = Wire {
+                        source: "grpc".to_string(),
+                        version: 0,
+                        tags: Default::default(),
+                    };
+
+                    let poke_success = client
+                        .poke(0, wire, slab.into())
+                        .await
+                        .map_err(|e| anyhow!("gRPC poke failed: {e}"))?;
+
+                    let noun = if poke_success { D(0) } else { D(1) };
+
+                    if self.process_out(false, noun) {
+                        println!("Poke success: {poke_success}");
                     }
                 }
                 Command::Eval(slab) => {

--- a/crates/kernels/jojo/Cargo.toml
+++ b/crates/kernels/jojo/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "kernels-open-jojo"
+version.workspace = true
+edition.workspace = true
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/crates/kernels/jojo/build.rs
+++ b/crates/kernels/jojo/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.ancestors().nth(3).expect("repo root");
+    let jam_path = repo_root.join("assets/jojo.jam");
+
+    println!("cargo:rerun-if-env-changed=KERNEL_JAM_PATH");
+    println!("cargo:rerun-if-changed={}", jam_path.display());
+
+    if env::var_os("KERNEL_JAM_PATH").is_none() {
+        println!("cargo:rustc-env=KERNEL_JAM_PATH={}", jam_path.display());
+    }
+}

--- a/crates/kernels/jojo/src/lib.rs
+++ b/crates/kernels/jojo/src/lib.rs
@@ -1,0 +1,1 @@
+pub static KERNEL: &[u8] = include_bytes!(env!("KERNEL_JAM_PATH"));

--- a/hoon/apps/jojo/jojo-imports.hoon
+++ b/hoon/apps/jojo/jojo-imports.hoon
@@ -1,0 +1,8 @@
+/=  transact  /common/tx-engine
+/=  mine  /common/pow
+/=  sp  /common/stark/prover
+/=  nv  /common/nock-verifier
+/=  *  /common/zeke
+/=  *  /common/zoon
+|%
+--

--- a/hoon/apps/jojo/jojo.hoon
+++ b/hoon/apps/jojo/jojo.hoon
@@ -1,0 +1,65 @@
+/=  z  /apps/jojo/jojo-imports
+/=  *  /common/wrapper
+=<  ((moat |) inner)  :: wrapped kernel
+=>
+  |%
+  +$  effect  [%jojo res=vase pret=(unit @t)]
+  +$  kernel-state  [%state version=%1]
+  +$  cause
+    :: $+  cause
+    $%  [%raw pret=bean hoon=@t subject=(unit *)]
+        [%sam pret=bean function-name=@t subject=(unit *) sample=*]
+        [%prt pret=bean val=vase]
+    ==
+  --
+|%
+++  moat  (keep kernel-state) :: no state
+++  inner
+  |_  k=kernel-state
+  ::  do-nothing load
+  ++  load
+    |=  =kernel-state  kernel-state
+  ::  crash-only peek
+  ++  peek
+    |=  arg=*
+    =/  pax  ((soft path) arg)
+    ?~  pax  ~|(not-a-path+arg !!)
+    ~|(invalid-peek+pax !!)
+  ::  poke: try to prove a block
+  ++  poke
+    |=  [wir=wire eny=@ our=@ux now=@da dat=*]
+    ^-  [(list effect) k=kernel-state]
+    |^
+    =/  cause  ((soft cause) dat)
+    ?~  cause
+      ~&  dat
+      ~>  %slog.[0 [%leaf "error: bad cause"]]
+      `k
+    =/  cause  u.cause
+    =/  res
+      ?-  -.cause
+        %sam  (do-sam function-name.cause sample.cause subject.cause)
+        %raw  (do-raw hoon.cause subject.cause)
+        %prt  `vase`[%noun +:val.cause] :: pretty printing with external vases may be long...
+      ==
+    =/  print
+      ?.  pret.cause  ~
+      [~ (crip (noah res))]
+    :_  k
+      [%jojo res print]~
+    ++  do-sam
+        |=  [function-name=@t sample=* subject=(unit *)]
+        =/  vas  ?~  subject
+          (slap !>(z) (ream function-name))
+          (slap !>(u.subject) (ream function-name))
+        =/  res  (slym vas sample)
+        res
+    ++  do-raw
+        |=  [hoon=@t subject=(unit *)]
+        =/  res  ?~  subject
+          (slap !>(z) (ream hoon))
+          (slap !>(u.subject) (ream hoon))
+        res
+    --
+  --
+--


### PR DESCRIPTION
A fast repl for poking around nouns and stuff.

Imports a bunch of ztd things in the subject.

Example:

```
❯ ./target/release/jojo shell
~nockvm:jojo〉add 6 7
13
~nockvm:jojo〉/= six 6
~nockvm:jojo〉/= seven 7
~nockvm:jojo〉/. [six seven] add
13
~nockvm:jojo〉/. [six six six six seven] |=  [a=* b=* c=*]  c
[6 6 7]
~nockvm:jojo〉/j [six six six six seven] test.jam
~nockvm:jojo〉
❯ ./target/release/jojo shell
~nockvm:jojo〉/c tuple test.jam
~nockvm:jojo〉/p tuple
[6 6 6 6 7]
~nockvm:jojo〉fink:fock (puzzle-nock [0 1 2 3 4] [5 4 3 2 1] 1)
[p=[132.855.709.512.001.719 0] q=[queue=~[132.855.709.512.001.719 [[6 [3 0 1] [0 0] 0 1] 1 0] [132.855.709.512.001.719 0] 132.855.709.512.001.719 0 132.855.709.512.001.719 [6 [3 0 1] [0 0] 0 1] 132.855.709.512.001.719 [0 1] 132.855.709.512.001.719 1 132.855.709.512.001.719 [1 0] 0 132.855.709.512.001.719 [0 1] 132.855.709.512.001.719 132.855.709.512.001.719 [3 0 1] 1 132.855.709.512.001.719 132.855.709.512.001.719 [0 1] 132.855.709.512.001.719] zeroes=[n=[p=subject=132.855.709.512.001.719 q=[n=[p=[axis=1 new-subject=132.855.709.512.001.719] q=count=2] l=~ r=~]] l=~ r=~] decodes=[n=[p=[formula=[[0 0] 0 1] head=[0 0] tail=[0 1]] q=count=1] l=~ r=[n=[p=[formula=[1 0] head=1 tail=0] q=count=1] l={} r={[p=[formula=[[6 [3 0 1] [0 0] 0 1] 1 0] head=[6 [3 0 1] [0 0] 0 1] tail=[1 0]] q=count=1] [p=[formula=[6 [3 0 1] [0 0] 0 1] head=6 tail=[[3 0 1] [0 0] 0 1]] q=count=1] [p=[formula=[3 0 1] head=3 tail=[0 1]] q=count=1] [p=[formula=[[3 0 1] [0 0] 0 1] head=[3 0 1] tail=[[0 0] 0 1]] q=count=1] [p=[formula=[0 1] head=0 tail=1] q=count=2]}]] s=132.855.709.512.001.719 f=[[6 [3 0 1] [0 0] 0 1] 1 0]]]
```

Full usage:

```
~nockvm:jojo〉/?
Usage:

/?, /help - display this message.
/. sam func - evaluate `func` with the given sample `sam`. Given sample can be constructed from variable assignments (using /=), and can be a cell, e.g. [a b].
// sam path - load `path` and evaluate its hoon with sample `sam`. Given sample can be constructed from variable assignments.
/: sub hoon - evaluate `hoon` with subject `sub`. Subject can be constructed from variable assignments.
/= var hoon - evaluage `hoon` and assign output to `var`.
/+ v s hoon - evaluate `hoon` on subject `s`, and assign output to `v`. Subject can be constructed from variable assignments.
/| v s func - evaluate `func` with the given sample `s` and assign output to `v`.
/p sam      - print given sample `sam`. Note: if single variable is provided, it is pretty-printed, but mutliple variables are printed as raw nouns.
/D sam      - (fast) debug print given sample `sam`. This will print the noun on rust side.
/v          - list defined variables.
/c var path - cue a jamfile at `path` and assign it to `var`.
/s var path - cue a subject jamfile at `path`, take the sample at axis 6, and assign it to `var`.
/j sam path - jam the given sample `sam` and write it to `path`.
/( var path - gRPC peek at given `path` and store it at `var`.
/< var s p  - gRPC peek with given sample `s` (attom sequence) appended to path `p`, and store it at `var`.
/> var sam  - gRPC poke with given sample `sam`, store the success at `var`.
hoon - evaluate `hoon` and print the result out to screen.

var = _ is a special case for 'do not store, print'
```