### PR TITLE
Feature: Offline/cold wallet signing

### DIFF
--- a/crates/nockchain-wallet/src/command.rs
+++ b/crates/nockchain-wallet/src/command.rs
@@ -422,9 +422,9 @@ pub enum Commands {
         /// Note selection strategy (ascending selects smallest notes first)
         #[arg(long = "note-selection", value_enum, default_value = "ascending")]
         note_selection_strategy: NoteSelectionStrategyCli,
-        /// Create an unsigned transaction (no private keys required, for watch-only wallets)
-        #[arg(long, default_value = "false")]
-        unsigned: bool,
+        /// Create an unsigned transaction for watch-only wallets. Provide the sender's pubkey hash (base58).
+        #[arg(long = "sender-pkh", value_name = "SENDER_PKH")]
+        sender_pkh: Option<String>,
     },
 
     /// Sign an unsigned or partially-signed transaction file

--- a/crates/nockchain-wallet/src/command.rs
+++ b/crates/nockchain-wallet/src/command.rs
@@ -12,6 +12,32 @@ use nockchain_types::tx_engine::v0;
 use crate::connection::ConnectionCli;
 use crate::recipient::{parse_recipient_arg, RecipientSpecToken};
 
+/// Unsigned refund recipient for watch-only wallets.
+///
+/// - `Pubkey`: base58-encoded schnorr public key (works for both v0 and v1 notes)
+/// - `Pkh`: base58-encoded pubkey hash (works for v1 notes only; v0 notes will error)
+#[derive(Clone, Debug)]
+pub enum UnsignedRefundRecipient {
+    Pubkey(String),
+    Pkh(String),
+}
+
+fn parse_unsigned_refund_recipient(s: &str) -> Result<UnsignedRefundRecipient, String> {
+    if let Some(pk) = s.strip_prefix("pubkey:") {
+        if pk.is_empty() {
+            return Err("pubkey value cannot be empty".into());
+        }
+        Ok(UnsignedRefundRecipient::Pubkey(pk.to_string()))
+    } else if let Some(pkh) = s.strip_prefix("pkh:") {
+        if pkh.is_empty() {
+            return Err("pkh value cannot be empty".into());
+        }
+        Ok(UnsignedRefundRecipient::Pkh(pkh.to_string()))
+    } else {
+        Err("Expected format: 'pubkey:<base58>' (v0+v1 notes) or 'pkh:<base58>' (v1 notes only)".into())
+    }
+}
+
 /// CLI helper that captures optional lower and upper bounds for timelocks.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -422,9 +448,14 @@ pub enum Commands {
         /// Note selection strategy (ascending selects smallest notes first)
         #[arg(long = "note-selection", value_enum, default_value = "ascending")]
         note_selection_strategy: NoteSelectionStrategyCli,
-        /// Create an unsigned transaction for watch-only wallets. Provide the sender's pubkey hash (base58).
-        #[arg(long = "sender-pkh", value_name = "SENDER_PKH")]
-        sender_pkh: Option<String>,
+        /// Create an unsigned transaction (watch-only wallet). Provide the refund
+        /// recipient as 'pubkey:<base58>' (v0+v1 notes) or 'pkh:<base58>' (v1 only).
+        #[arg(
+            long = "unsigned-refund-recipient",
+            value_name = "pubkey:BASE58|pkh:BASE58",
+            value_parser = parse_unsigned_refund_recipient
+        )]
+        unsigned_refund_recipient: Option<UnsignedRefundRecipient>,
     },
 
     /// Sign an unsigned or partially-signed transaction file

--- a/crates/nockchain-wallet/src/command.rs
+++ b/crates/nockchain-wallet/src/command.rs
@@ -195,6 +195,10 @@ pub struct WalletCli {
     #[arg(long, default_value = "false")]
     pub fakenet: bool,
 
+    /// Skip the gRPC balance sync (for air-gapped / offline signing)
+    #[arg(long, default_value = "false")]
+    pub offline: bool,
+
     #[command(flatten)]
     pub connection: ConnectionCli,
 
@@ -418,6 +422,21 @@ pub enum Commands {
         /// Note selection strategy (ascending selects smallest notes first)
         #[arg(long = "note-selection", value_enum, default_value = "ascending")]
         note_selection_strategy: NoteSelectionStrategyCli,
+        /// Create an unsigned transaction (no private keys required, for watch-only wallets)
+        #[arg(long, default_value = "false")]
+        unsigned: bool,
+    },
+
+    /// Sign an unsigned or partially-signed transaction file
+    SignTx {
+        /// Path to the transaction file to sign
+        transaction: String,
+        /// Optional key index to use for signing [0, 2^31)
+        #[arg(short, long, value_parser = clap::value_parser!(u64).range(0..2 << 31))]
+        index: Option<u64>,
+        /// Hardened or unhardened child key
+        #[arg(long, default_value = "false")]
+        hardened: bool,
     },
 
     /// Sign a multisig transaction
@@ -579,6 +598,7 @@ impl Commands {
             Commands::ListNotesByAddressCsv { .. } => "list-notes-by-address-csv",
             Commands::SetActiveMasterAddress { .. } => "set-active-master-address",
             Commands::CreateTx { .. } => "create-tx",
+            Commands::SignTx { .. } => "sign-tx",
             Commands::SignMultisigTx { .. } => "sign-multisig-tx",
             Commands::SendTx { .. } => "send-tx",
             Commands::ShowTx { .. } => "show-tx",

--- a/crates/nockchain-wallet/src/main.rs
+++ b/crates/nockchain-wallet/src/main.rs
@@ -115,6 +115,7 @@ async fn main() -> Result<(), NockAppError> {
         | Commands::ShowMasterZPrv
         | Commands::ShowKeyTree { .. }
         | Commands::ShowTx { .. }
+        | Commands::SignTx { .. }
         | Commands::SignMultisigTx { .. }
         | Commands::Watch { .. }
         | Commands::TxAccepted { .. } => false,
@@ -304,9 +305,14 @@ async fn main() -> Result<(), NockAppError> {
             sign_keys,
             save_raw_tx,
             note_selection_strategy,
+            unsigned,
         } => {
             let recipient_specs = recipient_tokens_to_specs(recipients.clone())?;
-            let signing_keys = Wallet::collect_signing_keys(*index, *hardened, sign_keys)?;
+            let signing_keys = if *unsigned {
+                Vec::new()
+            } else {
+                Wallet::collect_signing_keys(*index, *hardened, sign_keys)?
+            };
             Wallet::create_tx(
                 names.clone(),
                 recipient_specs,
@@ -317,8 +323,14 @@ async fn main() -> Result<(), NockAppError> {
                 *include_data,
                 *save_raw_tx,
                 *note_selection_strategy,
+                *unsigned,
             )
         }
+        Commands::SignTx {
+            transaction,
+            index,
+            hardened,
+        } => Wallet::sign_tx(transaction, *index, *hardened),
         Commands::SignMultisigTx {
             transaction,
             sign_keys,
@@ -343,7 +355,7 @@ async fn main() -> Result<(), NockAppError> {
     }?;
 
     // If this command requires sync, update the balance using a synchronous poke
-    if requires_sync {
+    if requires_sync && !cli.offline {
         info!(
             "Command requires syncing the current balance, connecting to Nockchain gRPC server..."
         );
@@ -571,7 +583,6 @@ impl Wallet {
     ///
     /// * `transaction_path` - Path to the transaction file
     /// * `index` - Optional index of the key to use for signing
-    #[allow(dead_code)]
     fn sign_tx(
         transaction_path: &str,
         index: Option<u64>,
@@ -607,14 +618,9 @@ impl Wallet {
             None => SIG,
         };
 
-        // Generate random entropy
-        let mut entropy_bytes = [0u8; 32];
-        getrandom::fill(&mut entropy_bytes).map_err(|e| CrownError::Unknown(e.to_string()))?;
-        let entropy = from_bytes(&mut slab, &entropy_bytes).as_noun();
-
         Self::wallet(
             "sign-tx",
-            &[transaction_noun, sign_key_noun, entropy],
+            &[transaction_noun, sign_key_noun],
             Operation::Poke,
             &mut slab,
         )
@@ -940,6 +946,7 @@ impl Wallet {
         include_data: bool,
         save_raw_tx: bool,
         note_selection: NoteSelectionStrategyCli,
+        unsigned: bool,
     ) -> CommandNoun<NounSlab> {
         let mut slab = NounSlab::new();
 
@@ -956,7 +963,11 @@ impl Wallet {
 
         let fee_noun = D(fee);
         let order_noun = recipients.to_noun(&mut slab);
-        let sign_key_noun = Wallet::encode_sign_keys(&mut slab, sign_keys);
+        let sign_key_noun = if unsigned {
+            SIG
+        } else {
+            Wallet::encode_sign_keys(&mut slab, sign_keys)
+        };
 
         let refund_noun = if let Some(refund) = refund_pkh {
             let refund_hash = Hash::from_base58(&refund).map_err(|err| {
@@ -974,12 +985,13 @@ impl Wallet {
         let allow_low_fee_noun = allow_low_fee.to_noun(&mut slab);
         let save_raw_tx_noun = save_raw_tx.to_noun(&mut slab);
         let note_selection_noun = make_tas(&mut slab, note_selection.tas_label()).as_noun();
+        let unsigned_noun = unsigned.to_noun(&mut slab);
 
         Self::wallet(
             "create-tx",
             &[
                 names_noun, order_noun, fee_noun, allow_low_fee_noun, sign_key_noun, refund_noun,
-                include_data_noun, save_raw_tx_noun, note_selection_noun,
+                include_data_noun, save_raw_tx_noun, note_selection_noun, unsigned_noun,
             ],
             Operation::Poke,
             &mut slab,

--- a/crates/nockchain-wallet/src/main.rs
+++ b/crates/nockchain-wallet/src/main.rs
@@ -305,10 +305,10 @@ async fn main() -> Result<(), NockAppError> {
             sign_keys,
             save_raw_tx,
             note_selection_strategy,
-            unsigned,
+            sender_pkh,
         } => {
             let recipient_specs = recipient_tokens_to_specs(recipients.clone())?;
-            let signing_keys = if *unsigned {
+            let signing_keys = if sender_pkh.is_some() {
                 Vec::new()
             } else {
                 Wallet::collect_signing_keys(*index, *hardened, sign_keys)?
@@ -323,7 +323,7 @@ async fn main() -> Result<(), NockAppError> {
                 *include_data,
                 *save_raw_tx,
                 *note_selection_strategy,
-                *unsigned,
+                sender_pkh.clone(),
             )
         }
         Commands::SignTx {
@@ -946,7 +946,7 @@ impl Wallet {
         include_data: bool,
         save_raw_tx: bool,
         note_selection: NoteSelectionStrategyCli,
-        unsigned: bool,
+        sender_pkh: Option<String>,
     ) -> CommandNoun<NounSlab> {
         let mut slab = NounSlab::new();
 
@@ -963,10 +963,24 @@ impl Wallet {
 
         let fee_noun = D(fee);
         let order_noun = recipients.to_noun(&mut slab);
-        let sign_key_noun = if unsigned {
-            SIG
+
+        // Encode the tx-key-info tagged union:
+        //   [%unsigned sender-pkh] for watch-only wallets
+        //   [%signed sign-keys]    for wallets with keys
+        let tx_key_info_noun = if let Some(ref pkh) = sender_pkh {
+            let unsigned_tag = make_tas(&mut slab, "unsigned").as_noun();
+            let pkh_hash = Hash::from_base58(pkh).map_err(|err| {
+                NockAppError::from(CrownError::Unknown(format!(
+                    "Invalid sender pubkey hash '{}': {}",
+                    pkh, err
+                )))
+            })?;
+            let pkh_noun = pkh_hash.to_noun(&mut slab);
+            T(&mut slab, &[unsigned_tag, pkh_noun])
         } else {
-            Wallet::encode_sign_keys(&mut slab, sign_keys)
+            let signed_tag = make_tas(&mut slab, "signed").as_noun();
+            let sign_key_noun = Wallet::encode_sign_keys(&mut slab, sign_keys);
+            T(&mut slab, &[signed_tag, sign_key_noun])
         };
 
         let refund_noun = if let Some(refund) = refund_pkh {
@@ -985,13 +999,19 @@ impl Wallet {
         let allow_low_fee_noun = allow_low_fee.to_noun(&mut slab);
         let save_raw_tx_noun = save_raw_tx.to_noun(&mut slab);
         let note_selection_noun = make_tas(&mut slab, note_selection.tas_label()).as_noun();
-        let unsigned_noun = unsigned.to_noun(&mut slab);
 
         Self::wallet(
             "create-tx",
             &[
-                names_noun, order_noun, fee_noun, allow_low_fee_noun, sign_key_noun, refund_noun,
-                include_data_noun, save_raw_tx_noun, note_selection_noun, unsigned_noun,
+                names_noun,
+                order_noun,
+                fee_noun,
+                allow_low_fee_noun,
+                tx_key_info_noun,
+                refund_noun,
+                include_data_noun,
+                save_raw_tx_noun,
+                note_selection_noun,
             ],
             Operation::Poke,
             &mut slab,

--- a/crates/nockchain-wallet/src/main.rs
+++ b/crates/nockchain-wallet/src/main.rs
@@ -26,7 +26,8 @@ use command::TimelockRangeCli;
 #[cfg(test)]
 use command::WalletWire;
 use command::{
-    ClientType, CommandNoun, Commands, NoteSelectionStrategyCli, WalletCli, WatchSubcommand,
+    ClientType, CommandNoun, Commands, NoteSelectionStrategyCli, UnsignedRefundRecipient,
+    WalletCli, WatchSubcommand,
 };
 use kernels_open_wallet::KERNEL;
 use nockapp::driver::*;
@@ -305,10 +306,21 @@ async fn main() -> Result<(), NockAppError> {
             sign_keys,
             save_raw_tx,
             note_selection_strategy,
-            sender_pkh,
+            unsigned_refund_recipient,
         } => {
             let recipient_specs = recipient_tokens_to_specs(recipients.clone())?;
-            let signing_keys = if sender_pkh.is_some() {
+            // Unsigned mode conflicts with signing key args
+            if unsigned_refund_recipient.is_some()
+                && (index.is_some() || !sign_keys.is_empty())
+            {
+                return Err(CrownError::Unknown(
+                    "Cannot specify signing keys (--index, --sign-key) with \
+                     --unsigned-refund-recipient"
+                        .into(),
+                )
+                .into());
+            }
+            let signing_keys = if unsigned_refund_recipient.is_some() {
                 Vec::new()
             } else {
                 Wallet::collect_signing_keys(*index, *hardened, sign_keys)?
@@ -323,7 +335,7 @@ async fn main() -> Result<(), NockAppError> {
                 *include_data,
                 *save_raw_tx,
                 *note_selection_strategy,
-                sender_pkh.clone(),
+                unsigned_refund_recipient.clone(),
             )
         }
         Commands::SignTx {
@@ -946,7 +958,7 @@ impl Wallet {
         include_data: bool,
         save_raw_tx: bool,
         note_selection: NoteSelectionStrategyCli,
-        sender_pkh: Option<String>,
+        unsigned_refund_recipient: Option<UnsignedRefundRecipient>,
     ) -> CommandNoun<NounSlab> {
         let mut slab = NounSlab::new();
 
@@ -965,22 +977,37 @@ impl Wallet {
         let order_noun = recipients.to_noun(&mut slab);
 
         // Encode the tx-key-info tagged union:
-        //   [%unsigned sender-pkh] for watch-only wallets
-        //   [%signed sign-keys]    for wallets with keys
-        let tx_key_info_noun = if let Some(ref pkh) = sender_pkh {
-            let unsigned_tag = make_tas(&mut slab, "unsigned").as_noun();
-            let pkh_hash = Hash::from_base58(pkh).map_err(|err| {
-                NockAppError::from(CrownError::Unknown(format!(
-                    "Invalid sender pubkey hash '{}': {}",
-                    pkh, err
-                )))
-            })?;
-            let pkh_noun = pkh_hash.to_noun(&mut slab);
-            T(&mut slab, &[unsigned_tag, pkh_noun])
-        } else {
-            let signed_tag = make_tas(&mut slab, "signed").as_noun();
-            let sign_key_noun = Wallet::encode_sign_keys(&mut slab, sign_keys);
-            T(&mut slab, &[signed_tag, sign_key_noun])
+        //   [%unsigned-pubkey pubkey]  for watch-only wallets (v0+v1)
+        //   [%unsigned-pkh sender-pkh] for watch-only wallets (v1 only)
+        //   [%signed sign-keys]        for wallets with keys
+        let tx_key_info_noun = match unsigned_refund_recipient {
+            Some(UnsignedRefundRecipient::Pubkey(ref pk)) => {
+                let tag = make_tas(&mut slab, "unsigned-pubkey").as_noun();
+                let pubkey = SchnorrPubkey::from_base58(pk).map_err(|err| {
+                    NockAppError::from(CrownError::Unknown(format!(
+                        "Invalid public key '{}': {}",
+                        pk, err
+                    )))
+                })?;
+                let pubkey_noun = pubkey.to_noun(&mut slab);
+                T(&mut slab, &[tag, pubkey_noun])
+            }
+            Some(UnsignedRefundRecipient::Pkh(ref pkh)) => {
+                let tag = make_tas(&mut slab, "unsigned-pkh").as_noun();
+                let pkh_hash = Hash::from_base58(pkh).map_err(|err| {
+                    NockAppError::from(CrownError::Unknown(format!(
+                        "Invalid sender pubkey hash '{}': {}",
+                        pkh, err
+                    )))
+                })?;
+                let pkh_noun = pkh_hash.to_noun(&mut slab);
+                T(&mut slab, &[tag, pkh_noun])
+            }
+            None => {
+                let signed_tag = make_tas(&mut slab, "signed").as_noun();
+                let sign_key_noun = Wallet::encode_sign_keys(&mut slab, sign_keys);
+                T(&mut slab, &[signed_tag, sign_key_noun])
+            }
         };
 
         let refund_noun = if let Some(refund) = refund_pkh {

--- a/crates/nockchain-wallet/src/main.rs
+++ b/crates/nockchain-wallet/src/main.rs
@@ -1411,7 +1411,7 @@ impl Wallet {
         };
 
         Self::wallet(
-            "sign-multisig-tx",
+            "sign-tx",
             &[transaction_noun, sign_keys_noun],
             Operation::Poke,
             &mut slab,

--- a/hoon/apps/wallet/lib/tx-builder.hoon
+++ b/hoon/apps/wallet/lib/tx-builder.hoon
@@ -13,7 +13,7 @@
         orders=(list order:wt)
         fee=coins:transact
         allow-low-fee=?
-        keys=$%([%signed sign-keys=(list schnorr-seckey:transact)] [%unsigned sender-pkh=hash:transact])
+        keys=$%([%signed sign-keys=(list schnorr-seckey:transact)] [%unsigned-pubkey signer-pubkey=schnorr-pubkey:transact] [%unsigned-pkh sender-pkh=hash:transact])
         refund-pkh=(unit hash:transact)
         get-note=$-(nname:transact nnote:transact)
         include-data=?
@@ -22,8 +22,9 @@
     ==
 =/  sign-keys=(list schnorr-seckey:transact)
   ?-  -.keys
-    %signed    sign-keys.keys
-    %unsigned  ~
+    %signed          sign-keys.keys
+    %unsigned-pubkey  ~
+    %unsigned-pkh     ~
   ==
 |^
 ^-  $:  spends:v1:transact
@@ -40,7 +41,10 @@
   ~|("At least one signing key is required for signed transactions" !!)
 =/  sender-pkh=hash:transact
   ?-  -.keys
-    %unsigned  sender-pkh.keys
+    %unsigned-pkh     sender-pkh.keys
+    %unsigned-pubkey
+      %-  hash:schnorr-pubkey:transact
+      signer-pubkey.keys
     %signed
       ?~  sign-keys  !!
       %-  hash:schnorr-pubkey:transact
@@ -48,10 +52,15 @@
       (to-atom:schnorr-seckey:transact i.sign-keys)
   ==
 =/  signer-pubkeys=(list schnorr-pubkey:transact)
-  %+  turn  sign-keys
-  |=  sk=schnorr-seckey:transact
-  %-  from-sk:schnorr-pubkey:transact
-  (to-atom:schnorr-seckey:transact sk)
+  ?-  -.keys
+    %unsigned-pubkey  ~[signer-pubkey.keys]
+    %unsigned-pkh     ~
+    %signed
+      %+  turn  sign-keys
+      |=  sk=schnorr-seckey:transact
+      %-  from-sk:schnorr-pubkey:transact
+      (to-atom:schnorr-seckey:transact sk)
+  ==
 =/  notes=(list nnote:transact)  (turn names get-note)
 =/  ascending=?  ?=(%asc note-selection)
 ::  If all notes are v0

--- a/hoon/apps/wallet/lib/tx-builder.hoon
+++ b/hoon/apps/wallet/lib/tx-builder.hoon
@@ -13,14 +13,18 @@
         orders=(list order:wt)
         fee=coins:transact
         allow-low-fee=?
-        sender-pkh=hash:transact
-        sign-keys=(list schnorr-seckey:transact)
+        keys=$%([%signed sign-keys=(list schnorr-seckey:transact)] [%unsigned sender-pkh=hash:transact])
         refund-pkh=(unit hash:transact)
         get-note=$-(nname:transact nnote:transact)
         include-data=?
         note-selection=selection-strategy:wt
         height=page-number:transact
     ==
+=/  sign-keys=(list schnorr-seckey:transact)
+  ?-  -.keys
+    %signed    sign-keys.keys
+    %unsigned  ~
+  ==
 |^
 ^-  $:  spends:v1:transact
         witness-data:wt
@@ -29,6 +33,20 @@
 =+  orders-valid=(orders-valid orders)
 ?:  ?=(%.n -.orders-valid)
   ~|("One or more orders are invalid. Reason: {<p.orders-valid>}" !!)
+::  for signed transactions, at least one signing key must be provided
+?:  ?&  ?=(%signed -.keys)
+        ?=(~ sign-keys)
+    ==
+  ~|("At least one signing key is required for signed transactions" !!)
+=/  sender-pkh=hash:transact
+  ?-  -.keys
+    %unsigned  sender-pkh.keys
+    %signed
+      ?~  sign-keys  !!
+      %-  hash:schnorr-pubkey:transact
+      %-  from-sk:schnorr-pubkey:transact
+      (to-atom:schnorr-seckey:transact i.sign-keys)
+  ==
 =/  signer-pubkeys=(list schnorr-pubkey:transact)
   %+  turn  sign-keys
   |=  sk=schnorr-seckey:transact
@@ -41,8 +59,6 @@
   ?:  (levy notes |=(=nnote:transact ?=(^ -.nnote)))
     ?~  refund-pkh
       ~|('Need to specify a refund address if spending from v0 notes. Use the `--refund-pkh` flag in the create-tx command' !!)
-    ?~  signer-pubkeys
-      ~|("At least one signing key is required when spending v0 notes" !!)
     =/  notes-v0=(list nnote:v0:transact)
       %+  turn  notes
       |=  =nnote:transact
@@ -52,6 +68,8 @@
       %+  sort  notes-v0
       |=  [a=nnote:v0:transact b=nnote:v0:transact]
       ?:(ascending (lth assets.a assets.b) (gth assets.a assets.b))
+    ?~  signer-pubkeys
+      ~|("At least one signing key is required when spending v0 notes" !!)
     =/  refund-lock=lock:transact  [%pkh [m=1 (z-silt:zo ~[u.refund-pkh])]]~
     (create-spends-0 notes-v0 orders fee i.signer-pubkeys refund-lock)
   ::  If all notes are v1

--- a/hoon/apps/wallet/lib/tx-builder.hoon
+++ b/hoon/apps/wallet/lib/tx-builder.hoon
@@ -13,6 +13,7 @@
         orders=(list order:wt)
         fee=coins:transact
         allow-low-fee=?
+        sender-pkh=hash:transact
         sign-keys=(list schnorr-seckey:transact)
         refund-pkh=(unit hash:transact)
         get-note=$-(nname:transact nnote:transact)
@@ -33,10 +34,6 @@
   |=  sk=schnorr-seckey:transact
   %-  from-sk:schnorr-pubkey:transact
   (to-atom:schnorr-seckey:transact sk)
-?~  signer-pubkeys
-  ~|("At least one signing key is required" !!)
-=/  sender-pubkey=schnorr-pubkey:transact  i.signer-pubkeys
-=/  sender-pkh=hash:transact  (hash:schnorr-pubkey:transact sender-pubkey)
 =/  notes=(list nnote:transact)  (turn names get-note)
 =/  ascending=?  ?=(%asc note-selection)
 ::  If all notes are v0
@@ -44,6 +41,8 @@
   ?:  (levy notes |=(=nnote:transact ?=(^ -.nnote)))
     ?~  refund-pkh
       ~|('Need to specify a refund address if spending from v0 notes. Use the `--refund-pkh` flag in the create-tx command' !!)
+    ?~  signer-pubkeys
+      ~|("At least one signing key is required when spending v0 notes" !!)
     =/  notes-v0=(list nnote:v0:transact)
       %+  turn  notes
       |=  =nnote:transact
@@ -54,7 +53,7 @@
       |=  [a=nnote:v0:transact b=nnote:v0:transact]
       ?:(ascending (lth assets.a assets.b) (gth assets.a assets.b))
     =/  refund-lock=lock:transact  [%pkh [m=1 (z-silt:zo ~[u.refund-pkh])]]~
-    (create-spends-0 notes-v0 orders fee sender-pubkey refund-lock)
+    (create-spends-0 notes-v0 orders fee i.signer-pubkeys refund-lock)
   ::  If all notes are v1
   ?:  (levy notes |=(=nnote:transact ?=(@ -.nnote)))
     =/  notes-v1=(list nnote-1:v1:transact)

--- a/hoon/apps/wallet/lib/types.hoon
+++ b/hoon/apps/wallet/lib/types.hoon
@@ -432,6 +432,7 @@
             save-raw-tx=?                                 ::  if %.y, saves jams of the raw-tx and its hashable into a txs-debug folder
                                                           ::  in the current working directory
             =selection-strategy
+            unsigned=?                                            ::  if %.y, skip signing (for watch-only wallets)
         ==
         [%list-active-addresses ~]
         [%list-notes ~]
@@ -446,6 +447,10 @@
         [%list-master-addresses ~]
         [%file file-cause]
         $:  %sign-multisig-tx
+            dat=transaction
+            sign-keys=(unit (list [child-index=@ud hardened=?]))
+        ==
+        $:  %sign-tx
             dat=transaction
             sign-keys=(unit (list [child-index=@ud hardened=?]))
         ==

--- a/hoon/apps/wallet/lib/types.hoon
+++ b/hoon/apps/wallet/lib/types.hoon
@@ -455,10 +455,6 @@
         [%set-active-master-address address-b58=@t]
         [%list-master-addresses ~]
         [%file file-cause]
-        $:  %sign-multisig-tx
-            dat=transaction
-            sign-keys=(unit (list [child-index=@ud hardened=?]))
-        ==
         $:  %sign-tx
             dat=transaction
             sign-keys=(unit (list [child-index=@ud hardened=?]))

--- a/hoon/apps/wallet/lib/types.hoon
+++ b/hoon/apps/wallet/lib/types.hoon
@@ -400,11 +400,13 @@
   ::  $tx-key-info: tagged union for signing info passed in create-tx cause
   ::
   ::    %signed: wallet has keys; sign-keys is the (unit list) of child-key specs
-  ::    %unsigned: watch-only wallet; sender-pkh is provided directly
+  ::    %unsigned-pubkey: watch-only wallet; signer-pubkey provided (v0+v1 notes)
+  ::    %unsigned-pkh: watch-only wallet; sender-pkh provided directly (v1 only)
   ::
   +$  tx-key-info
     $%  [%signed sign-keys=(unit (list [child-index=@ud hardened=?]))]
-        [%unsigned sender-pkh=hash:transact]
+        [%unsigned-pubkey signer-pubkey=schnorr-pubkey:transact]
+        [%unsigned-pkh sender-pkh=hash:transact]
     ==
   ::
   +$  cause
@@ -432,7 +434,7 @@
             orders=(list order)
             fee=coins:transact                            ::  fee
             allow-low-fee=?                               ::  bypass min fee check (unsafe, testing only)
-            =tx-key-info                                  ::  either signed (child-key specs) or unsigned (sender-pkh)
+            =tx-key-info                                  ::  signed (child-key specs), unsigned-pubkey, or unsigned-pkh
             refund-pkh=(unit hash:transact)               ::  refund pkh for spends over v0 notes
             include-data=?                                ::  whether or not we should include note-data. defaults
                                                           ::  to yes in cli. not including note-data is a power-user option because

--- a/hoon/apps/wallet/lib/types.hoon
+++ b/hoon/apps/wallet/lib/types.hoon
@@ -397,6 +397,16 @@
   ::
   ++  key-version  ?(%0 %1)
   ::
+  ::  $tx-key-info: tagged union for signing info passed in create-tx cause
+  ::
+  ::    %signed: wallet has keys; sign-keys is the (unit list) of child-key specs
+  ::    %unsigned: watch-only wallet; sender-pkh is provided directly
+  ::
+  +$  tx-key-info
+    $%  [%signed sign-keys=(unit (list [child-index=@ud hardened=?]))]
+        [%unsigned sender-pkh=hash:transact]
+    ==
+  ::
   +$  cause
     $%  [%keygen entropy=byts salt=byts]
         [%derive-child i=@ hardened=? label=(unit @tas)]
@@ -422,7 +432,7 @@
             orders=(list order)
             fee=coins:transact                            ::  fee
             allow-low-fee=?                               ::  bypass min fee check (unsafe, testing only)
-            sign-keys=(unit (list [child-index=@ud hardened=?]))  ::  child key information to sign from
+            =tx-key-info                                  ::  either signed (child-key specs) or unsigned (sender-pkh)
             refund-pkh=(unit hash:transact)               ::  refund pkh for spends over v0 notes
             include-data=?                                ::  whether or not we should include note-data. defaults
                                                           ::  to yes in cli. not including note-data is a power-user option because
@@ -432,7 +442,6 @@
             save-raw-tx=?                                 ::  if %.y, saves jams of the raw-tx and its hashable into a txs-debug folder
                                                           ::  in the current working directory
             =selection-strategy
-            unsigned=?                                            ::  if %.y, skip signing (for watch-only wallets)
         ==
         [%list-active-addresses ~]
         [%list-notes ~]

--- a/hoon/apps/wallet/wallet.hoon
+++ b/hoon/apps/wallet/wallet.hoon
@@ -216,7 +216,6 @@
         %list-notes-by-address-csv  (do-list-notes-by-address-csv cause)
         %create-tx             (do-create-tx cause)
         %sign-tx               (do-sign-tx cause)
-        %sign-multisig-tx      (do-sign-multisig-tx cause)
         %update-balance-grpc   (do-update-balance-grpc cause)
         %sign-message          (do-sign-message cause)
         %verify-message        (do-verify-message cause)
@@ -1694,13 +1693,8 @@
   ++  do-sign-tx
     |=  =cause:wt
     ?>  ?=(%sign-tx -.cause)
-    (do-sign-multisig-tx cause(- %sign-multisig-tx))
-  ::
-  ++  do-sign-multisig-tx
-    |=  =cause:wt
-    ?>  ?=(%sign-multisig-tx -.cause)
     |^
-    %-  (debug "sign-multisig-tx: {<name.dat.cause>}")
+    %-  (debug "sign-tx: {<name.dat.cause>}")
     ?~  active-master.state
       :_  state
       :~  :-  %markdown

--- a/hoon/apps/wallet/wallet.hoon
+++ b/hoon/apps/wallet/wallet.hoon
@@ -1279,10 +1279,11 @@
           """
           [%exit 0]
       ==
-    ::  %unsigned: pass sender-pkh directly; %signed: resolve key-indices to secret keys
+    ::  %unsigned-*: pass through directly; %signed: resolve key-indices to secret keys
     =/  builder-keys
       ?-  -.tx-key-info.cause
-        %unsigned  tx-key-info.cause
+        %unsigned-pkh     tx-key-info.cause
+        %unsigned-pubkey  tx-key-info.cause
         %signed
           :-  %signed
           ?~  sign-keys.tx-key-info.cause

--- a/hoon/apps/wallet/wallet.hoon
+++ b/hoon/apps/wallet/wallet.hoon
@@ -1268,35 +1268,37 @@
     %-  (debug "create-tx: {<names.cause>}")
     =/  names=(list nname:transact)  (parse-names names.cause)
     =/  orders=(list order:wt)  orders.cause
-    ?~  active-master.state
+    ::  for signed transactions, we need an active master key in the wallet
+    ?:  ?&  ?=(%signed -.tx-key-info.cause)
+            ?=(~ active-master.state)
+        ==
       :_  state
       :~  :-  %markdown
           %-  crip
           """
-          Cannot create a transaction without active master address set. Please import a master key / seed phrase or generate a new one.
+          Cannot create a signed transaction without active master address set. Please import a master key / seed phrase or generate a new one.
           """
           [%exit 0]
       ==
-    =/  master-coil=coil:wt  ~(master get:v %pub)
-    ?>  ?=(%pub -.key.master-coil)
-    =/  sender-pkh=hash:transact
-      %-  hash:schnorr-pubkey:transact
-      (from-ser:schnorr-pubkey:transact p.key.master-coil)
-    =/  sign-keys=(list schnorr-seckey:transact)
-      ?:  unsigned.cause  ~
-      ?~  sign-keys.cause
-        ~[(sign-key:get:v ~)]
-      %+  turn  u.sign-keys.cause
-      |=  key-info=[child-index=@ud hardened=?]
-      (sign-key:get:v [~ key-info])
+    ::  %unsigned: pass sender-pkh directly; %signed: resolve key-indices to secret keys
+    =/  builder-keys
+      ?-  -.tx-key-info.cause
+        %unsigned  tx-key-info.cause
+        %signed
+          :-  %signed
+          ?~  sign-keys.tx-key-info.cause
+            ~[(sign-key:get:v ~)]
+          %+  turn  u.sign-keys.tx-key-info.cause
+          |=  key-info=[child-index=@ud hardened=?]
+          (sign-key:get:v [~ key-info])
+      ==
     =/  [=spends:v1:transact =witness-data:wt display=transaction-display:wt]
       %:  ~(build tx-builder bc.state)
         names
         orders
         fee.cause
         allow-low-fee.cause
-        sender-pkh
-        sign-keys
+        builder-keys
         refund-pkh.cause
         get-note:v
         include-data.cause

--- a/hoon/apps/wallet/wallet.hoon
+++ b/hoon/apps/wallet/wallet.hoon
@@ -215,6 +215,7 @@
         %list-notes-by-address  (do-list-notes-by-address cause)
         %list-notes-by-address-csv  (do-list-notes-by-address-csv cause)
         %create-tx             (do-create-tx cause)
+        %sign-tx               (do-sign-tx cause)
         %sign-multisig-tx      (do-sign-multisig-tx cause)
         %update-balance-grpc   (do-update-balance-grpc cause)
         %sign-message          (do-sign-message cause)
@@ -1276,7 +1277,13 @@
           """
           [%exit 0]
       ==
+    =/  master-coil=coil:wt  ~(master get:v %pub)
+    ?>  ?=(%pub -.key.master-coil)
+    =/  sender-pkh=hash:transact
+      %-  hash:schnorr-pubkey:transact
+      (from-ser:schnorr-pubkey:transact p.key.master-coil)
     =/  sign-keys=(list schnorr-seckey:transact)
+      ?:  unsigned.cause  ~
       ?~  sign-keys.cause
         ~[(sign-key:get:v ~)]
       %+  turn  u.sign-keys.cause
@@ -1288,6 +1295,7 @@
         orders
         fee.cause
         allow-low-fee.cause
+        sender-pkh
         sign-keys
         refund-pkh.cause
         get-note:v
@@ -1680,6 +1688,11 @@
         """
         [%exit 0]
     ==
+  ::
+  ++  do-sign-tx
+    |=  =cause:wt
+    ?>  ?=(%sign-tx -.cause)
+    (do-sign-multisig-tx cause(- %sign-multisig-tx))
   ::
   ++  do-sign-multisig-tx
     |=  =cause:wt


### PR DESCRIPTION
The current version of the wallet does not support creating transactions on an offline/airgapped machine. This is important to be able to securely custody meaningful amounts of funds.

This PR adds an offline signing workflow:
  - --offline flag: skips the gRPC balance sync, so the wallet can run on an air-gapped machine
  - --unsigned flag on create-tx: builds a transaction without needing private keys, enabling watch-only wallet workflows (with inline note metadata overrides via [first last]:assets:origin-page so the node doesn't need to be reachable)
  - sign-tx command: signs the unsigned transaction offline on a separate, secure machine

The workflow is: generate an unsigned transaction on a hot machine via pubkey, transfer the transaction to an air-gapped signer with the private key, sign it offline, then transfer it back to the hot machine for broadcast.