### PR TITLE
Add h-zoon

### DIFF
--- a/hoon/apps/dumbnet/inner.hoon
+++ b/hoon/apps/dumbnet/inner.hoon
@@ -7,7 +7,7 @@
 /=  mine  /common/pow
 /=  nv  /common/nock-verifier
 /=  zeke  /common/zeke
-/=  *  /common/zoon
+/=  *  /common/h-zoon
 /=  *  /common/wrapper
 ::
 ::  Never use c-transact face, always use the lustar `t`
@@ -36,14 +36,14 @@
     ~&  [%nockchain-state-version -.arg]
     ::  cut
     |^
-    =.  k  ~>  %bout  (update-constants (check-checkpoints (state-n-to-6 arg)))
+    =.  k  ~>  %bout  (update-constants (check-checkpoints (state-n-to-7 arg)))
     =.  c.k  ~>  %bout  check-and-repair:con
     k
     ::  this arm should be renamed each state upgrade to state-n-to-[latest] and extended to loop through all upgrades
-    ++  state-n-to-6
+    ++  state-n-to-7
       |=  arg=load-kernel-state:dk
       ^-  kernel-state:dk
-      ?.  ?=(%6 -.arg)
+      ?.  ?=(%7 -.arg)
         ~>  %slog.[0 'load: State upgrade required']
         ?-  -.arg
             ::
@@ -53,8 +53,39 @@
           %3  $(arg (state-3-to-4 arg))
           %4  $(arg (state-4-to-5 arg))
           %5  $(arg (state-5-to-6 arg))
+          %6  $(arg (state-6-to-7 arg))
         ==
       arg
+    ::
+    ::  upgrade kernel state 6 to kernel state 7
+    ++  state-6-to-7
+      |=  arg=kernel-state-6:dk
+      ^-  kernel-state-7:dk
+      =/  new-c=consensus-state-7:dk
+        %*  .  *consensus-state-7:dk
+          blocks-needed-by  (zh-jult blocks-needed-by.c.arg)
+          excluded-txs      (zh-silt excluded-txs.c.arg)
+          spent-by          (zh-jult spent-by.c.arg)
+          pending-blocks    (zh-molt pending-blocks.c.arg)
+          balance           (zh-milt balance.c.arg)
+          txs               (zh-milt txs.c.arg)
+          raw-txs           (zh-molt raw-txs.c.arg)
+          blocks            (zh-molt blocks.c.arg)
+          heaviest-block    heaviest-block.c.arg
+          min-timestamps    (zh-molt min-timestamps.c.arg)
+          epoch-start       (zh-molt epoch-start.c.arg)
+          targets           (zh-molt targets.c.arg)
+          btc-data          btc-data.c.arg
+          genesis-seal      genesis-seal.c.arg
+        ==
+      :*  %7
+          c=new-c
+          a=a.arg
+          m=m.arg
+          d=d.arg
+          constants=constants.arg
+      ==
+
     ::
     ::  upgrade kernel state 5 to kernel state 6
     ++  state-5-to-6
@@ -294,19 +325,36 @@
     ::
         [%blocks ~]
       ^-  (unit (unit (z-map block-id:t page:t)))
-      ``(~(run z-by blocks.c.k) to-page:local-page:t)
+      ``(hz-molt (~(run h-by blocks.c.k) to-page:local-page:t))
+    ::
+        [%h-blocks ~]
+      ^-  (unit (unit (h-map block-id:t page:t)))
+      ``(~(run h-by blocks.c.k) to-page:local-page:t)
     ::
         [%transactions ~]
       ^-  (unit (unit (z-mip block-id:t tx-id:t tx:t)))
+      ``(hz-milt txs.c.k)
+    ::
+        [%h-transactions ~]
+      ^-  (unit (unit (h-mip block-id:t tx-id:t tx:t)))
       ``txs.c.k
     ::
         [%raw-transactions ~]
       ^-  (unit (unit (z-map tx-id:t [=raw-tx:t heard-at=@])))
+      ``(hz-molt raw-txs.c.k)
+    ::
+        [%h-raw-transactions ~]
+      ^-  (unit (unit (h-map tx-id:t [=raw-tx:t heard-at=@])))
       ``raw-txs.c.k
     ::
       :: transactions unneeded by any block
         [%excluded-txs ~]
       ^-  (unit (unit (z-set tx-id:t)))
+      ``(hz-silt excluded-txs.c.k)
+    ::
+      :: transactions unneeded by any block
+        [%h-excluded-txs ~]
+      ^-  (unit (unit (h-set tx-id:t)))
       ``excluded-txs.c.k
     ::
     ::  For %block, %transaction, %raw-transaction, and %balance scries, the ID is
@@ -315,7 +363,7 @@
       ^-  (unit (unit page:t))
       :: scry for a validated block (this does not look at pending state)
       =/  block-id  (from-b58:hash:t bid.pole)
-      `(bind (~(get z-by blocks.c.k) block-id) to-page:local-page:t)
+      `(bind (~(get h-by blocks.c.k) block-id) to-page:local-page:t)
     ::
         [%elders bid=@ ~]
       ::  get ancestor block IDs up to 24 deep for a given block
@@ -330,7 +378,16 @@
       ::  scry for txs included in a validated block
       ^-  (unit (unit (z-map tx-id:t tx:t)))
       :-  ~
-      %-  ~(get z-by txs.c.k)
+      %+  bind
+      %-  ~(get h-by txs.c.k)
+      (from-b58:hash:t bid.pole)
+      hz-molt
+    ::
+        [%h-block-transactions bid=@ ~]
+      ::  scry for txs included in a validated block
+      ^-  (unit (unit (h-map tx-id:t tx:t)))
+      :-  ~
+      %-  ~(get h-by txs.c.k)
       (from-b58:hash:t bid.pole)
     ::
         [%block-transaction bid=@ tid=@ ~]
@@ -338,9 +395,9 @@
       ^-  (unit (unit tx:t))
       =/  tx-id  (from-b58:hash:t tid.pole)
       =/  block-id  (from-b58:hash:t bid.pole)
-      =/  block-txs  (~(get z-by txs.c.k) block-id)
+      =/  block-txs  (~(get h-by txs.c.k) block-id)
       ?~  block-txs  ~
-      =/  maybe-tx  (~(get z-by u.block-txs) tx-id)
+      =/  maybe-tx  (~(get h-by u.block-txs) tx-id)
       ?~  maybe-tx  ~
       ``u.maybe-tx
     ::
@@ -364,7 +421,7 @@
         (~(get z-by heaviest-chain.d.k) u.num)
       ?~  id
         [~ ~]
-      `(bind (~(get z-by blocks.c.k) u.id) to-page:local-page:t)
+      `(bind (~(get h-by blocks.c.k) u.id) to-page:local-page:t)
     ::
         [%heaviest-chain ~]
       ^-  (unit (unit [page-number:t block-id:t]))
@@ -403,14 +460,22 @@
         [%balance bid=@ ~]
       ^-  (unit (unit (z-map nname:t nnote:t)))
       :-  ~
-      %-  ~(get z-by balance.c.k)
+      %+  bind
+      %-  ~(get h-by balance.c.k)
+      (from-b58:hash:t bid.pole)
+      hz-molt
+    ::
+        [%h-balance bid=@ ~]
+      ^-  (unit (unit (h-map nname:t nnote:t)))
+      :-  ~
+      %-  ~(get h-by balance.c.k)
       (from-b58:hash:t bid.pole)
     ::
         [%heaviest-block ~]
       ^-  (unit (unit page:t))
       ?~  heaviest-block.c.k
         [~ ~]
-      =/  heaviest-block  (~(get z-by blocks.c.k) u.heaviest-block.c.k)
+      =/  heaviest-block  (~(get h-by blocks.c.k) u.heaviest-block.c.k)
       ?~  heaviest-block  ~
       ``(to-page:local-page:t u.heaviest-block)
     ::
@@ -418,10 +483,22 @@
       ^-  (unit (unit (z-map nname:t nnote:t)))
       ?~  heaviest-block.c.k
         [~ ~]
-      ?.  (~(has z-by blocks.c.k) u.heaviest-block.c.k)
+      ?.  (~(has h-by blocks.c.k) u.heaviest-block.c.k)
         [~ ~]
       :-  ~
-      %-  ~(get z-by balance.c.k)
+      %+  bind
+      %-  ~(get h-by balance.c.k)
+      u.heaviest-block.c.k
+      hz-molt
+    ::
+        [%h-current-balance ~]
+      ^-  (unit (unit (h-map nname:t nnote:t)))
+      ?~  heaviest-block.c.k
+        [~ ~]
+      ?.  (~(has h-by blocks.c.k) u.heaviest-block.c.k)
+        [~ ~]
+      :-  ~
+      %-  ~(get h-by balance.c.k)
       u.heaviest-block.c.k
     ::
         [%balance-by-first-name first-name=@t ~]
@@ -429,9 +506,9 @@
       =/  first-name=hash:t  (from-b58:hash:t first-name.pole)
       ?~  heaviest-block.c.k
         [~ ~]
-      ?.  (~(has z-by blocks.c.k) u.heaviest-block.c.k)
+      ?.  (~(has h-by blocks.c.k) u.heaviest-block.c.k)
         [~ ~]
-      ?~  bal=(~(get z-by balance.c.k) u.heaviest-block.c.k)
+      ?~  bal=(~(get h-by balance.c.k) u.heaviest-block.c.k)
         [~ ~]
       ?~  highest=highest-block-height.d.k
         [~ ~]
@@ -439,7 +516,7 @@
       %-  some
       :+  u.highest
         u.heaviest-block.c.k
-      %-  ~(rep z-by u.bal)
+      %-  ~(rep h-by u.bal)
       |=  [[k=nname:t v=nnote:t] bal=(z-map nname:t nnote:t)]
       ?.  =(~(first-name get:nnote:t v) first-name)
         bal
@@ -450,9 +527,9 @@
       =/  pubkey=schnorr-pubkey:t  (from-b58:schnorr-pubkey:t key-b58.pole)
       ?~  heaviest-block.c.k
         [~ ~]
-      ?.  (~(has z-by blocks.c.k) u.heaviest-block.c.k)
+      ?.  (~(has h-by blocks.c.k) u.heaviest-block.c.k)
         [~ ~]
-      ?~  bal=(~(get z-by balance.c.k) u.heaviest-block.c.k)
+      ?~  bal=(~(get h-by balance.c.k) u.heaviest-block.c.k)
         [~ ~]
       ?~  highest=highest-block-height.d.k
         [~ ~]
@@ -460,7 +537,7 @@
       %-  some
       :+  u.highest
         u.heaviest-block.c.k
-      %-  ~(rep z-by u.bal)
+      %-  ~(rep h-by u.bal)
       |=  [[k=nname:t v=nnote:t] pub-bal=(z-map nname:t nnote:t)]
       ::  only include v0 notes; v1 notes use lock-roots
       ?.  ?=(^ -.v)
@@ -475,7 +552,7 @@
       ^-  (unit (unit [(each (z-set sig:t) (z-set hash:t)) (unit page-summary:t)]))
       ?~  heaviest-block.c.k
         ``[[%& ~(key z-by v0-shares.m.k)] ~]
-      =/  heaviest-block  (~(get z-by blocks.c.k) u.heaviest-block.c.k)
+      =/  heaviest-block  (~(get h-by blocks.c.k) u.heaviest-block.c.k)
       ?~  heaviest-block
         ``[[%& ~(key z-by v0-shares.m.k)] ~]
       ?~  highest-block-height.d.k
@@ -492,9 +569,9 @@
       ^-  (unit (unit (list [block-id:t page:t])))
       :-  ~
       :-  ~
-      %~  tap  z-by
-      ^-  (z-map block-id:t page:t)
-      %-  ~(run z-by blocks.c.k)
+      %~  tap  h-by
+      ^-  (h-map block-id:t page:t)
+      %-  ~(run h-by blocks.c.k)
       |=  lp=local-page:t
       ^-  page:t
       ?^  -.lp  lp(pow ~)
@@ -503,7 +580,7 @@
         [%tx-accepted tid-b58=@t ~]
       ^-  (unit (unit ?))
       =+  tid=(from-b58:hash:t tid-b58:pole)
-      ``(~(has z-by raw-txs.c.k) tid)
+      ``(~(has h-by raw-txs.c.k) tid)
     ==
     ++  heaviest-chain-blocks-range
       |=  [start=@ end=@ include-pow=?]
@@ -532,13 +609,13 @@
           $(height +(height))
         ::  get block data
         =/  local-block=(unit local-page:t)
-          (~(get z-by blocks.c.k) u.block-id)
+          (~(get h-by blocks.c.k) u.block-id)
         ?~  local-block
           $(height +(height))
         ::  get transactions for this block
-        =/  block-txs=(unit (z-map tx-id:t tx:t))
-          (~(get z-by txs.c.k) u.block-id)
-        =/  txs-map  ?~(block-txs ~ u.block-txs)
+        =/  block-txs=(unit (h-map tx-id:t tx:t))
+          (~(get h-by txs.c.k) u.block-id)
+        =/  txs-map  ?~(block-txs ~ (hz-molt u.block-txs))
         ::  add to result list
         :-  [height u.block-id (to-page u.local-block) txs-map]
         $(height +(height))
@@ -580,7 +657,7 @@
     :_  effs
     =/  version=proof-version:sp
       (height-to-proof-version:con ~(height get:page:t candidate-block.m.k))
-    =/  target  (~(got z-by targets.c.k) ~(parent get:page:t candidate-block.m.k))
+    =/  target  (~(got h-by targets.c.k) ~(parent get:page:t candidate-block.m.k))
     =/  commit  (block-commitment:page:t candidate-block.m.k)
     ?-  version
       %0  [%mine %0 commit target pow-len:t]
@@ -624,9 +701,9 @@
         (missing-parent-effects ~(digest get:page:t pag) ~(height get:page:t pag) u.peer-id)
       ::  if we don't have parent and block claims to be heaviest
       ::  request ancestors to catch up or handle reorg
-      ?.  (~(has z-by blocks.c.k) ~(parent get:page:t pag))
+      ?.  (~(has h-by blocks.c.k) ~(parent get:page:t pag))
         ?:  %+  compare-heaviness:page:t  pag
-            (~(got z-by blocks.c.k) u.heaviest-block.c.k)
+            (~(got h-by blocks.c.k) u.heaviest-block.c.k)
           =/  peer-id=(unit @)  (get-peer-id wir)
           ?~  peer-id
             ~|("heard-block: Unsupported wire: {<wir>}" !!)
@@ -712,7 +789,7 @@
           [%request %raw-tx %by-id tx-id]
         :_  k
         ?:  %+  compare-heaviness:page:t  pag
-            (~(got z-by blocks.c.k) (need heaviest-block.c.k))
+            (~(got h-by blocks.c.k) (need heaviest-block.c.k))
           ~>  %slog.[0 'heard-block: Gossiping new heaviest block (transactions pending validation)']
           :-  [%gossip %0 %heard-block pag]
           block-effs
@@ -760,7 +837,7 @@
         |-
         ?~  ids  ~
         ?:  =(height 0)  ~
-        ?:  (~(has z-by blocks.c.k) i.ids)
+        ?:  (~(has h-by blocks.c.k) i.ids)
           `[i.ids height]
         $(ids t.ids, height (dec height))
       ?~  latest-known
@@ -802,8 +879,8 @@
     ::
     ++  check-duplicate-block
       |=  digest=block-id:t
-      ?|  (~(has z-by blocks.c.k) digest)
-          (~(has z-by pending-blocks.c.k) digest)
+      ?|  (~(has h-by blocks.c.k) digest)
+          (~(has h-by pending-blocks.c.k) digest)
       ==
     ::
     ++  check-genesis
@@ -824,7 +901,7 @@
      ::  since child block timestamps have to be within a certain range of the most recent
      ::  N blocks.
      =/  check-timestamp=?  (based:zeke ~(timestamp get:page:t pag))
-     =/  check-txs=?  =(~(tx-ids get:page:t pag) *(z-set tx-id:t))
+     =/  check-txs=?  =(~(tx-ids get:page:t pag) *(h-set tx-id:t))
      =/  check-epoch=?  =(~(epoch-counter get:page:t pag) *@)
      =/  check-target=?  =(~(target get:page:t pag) genesis-target:t)
      =/  check-work=?  =(~(accumulated-work get:page:t pag) (compute-work:page:t genesis-target:t))
@@ -950,9 +1027,9 @@
           ::  won't accidentally throw out a block that contained a valid tx-id
           ::  just because we received a tx that claimed the same id as the valid
           ::  one.
-          =/  tx-pending-blocks  (~(get z-ju blocks-needed-by.c.k) ~(id get:raw-tx:t raw))
+          =/  tx-pending-blocks  (~(get h-ju blocks-needed-by.c.k) ~(id get:raw-tx:t raw))
           =.  c.k
-            %-  ~(rep z-in tx-pending-blocks)
+            %-  ~(rep h-in tx-pending-blocks)
             |=  [id=block-id:t c=_c.k]
             =.  c.k  c
             (reject-pending-block:con id)
@@ -1024,7 +1101,7 @@
         =^  new-effs  k
           %:  process-block-with-txs
             now  eny
-            page:(~(got z-by pending-blocks.c.k) bid)
+            page:(~(got h-by pending-blocks.c.k) bid)
             :: if the block is bad, then tell the driver we dont want to see it
             :: again
             ~[[%seen %block bid ~]]
@@ -1163,7 +1240,7 @@
       ::
       ::  if new block is heaviest, regossip txs that haven't been garbage collected
       =?  effs  is-new-heaviest
-        %-  ~(rep z-in excluded-txs.c.k)
+        %-  ~(rep h-in excluded-txs.c.k)
         |=  [=tx-id:t effs=_effs]
         [[%gossip %0 %heard-tx (got-raw-tx:con tx-id)] effs]
       ::  regossip block transactions if mining
@@ -1296,7 +1373,7 @@
         :: of height N+1
         :: Also emit %seen for the heaviest block so our cache can start to update
         =/  height=page-number:t
-          +(~(height get:local-page:t (~(got z-by blocks.c.k) u.heaviest-block.c.k)))
+          +(~(height get:local-page:t (~(got h-by blocks.c.k) u.heaviest-block.c.k)))
         =/  born-effects=(list effect:dk)
           :~  [%request %block %by-height height]
               [%seen %block u.heaviest-block.c.k `height]
@@ -1434,7 +1511,7 @@
         =/  heavy-height=page-number:t
           ?~  heaviest-block.c.k
             *page-number:t  ::  rerequest genesis block
-          +(~(height get:local-page:t (~(got z-by blocks.c.k) u.heaviest-block.c.k)))
+          +(~(height get:local-page:t (~(got h-by blocks.c.k) u.heaviest-block.c.k)))
         =.  effects
           [[%request %block %by-height heavy-height] effects]
         =.  effects
@@ -1552,7 +1629,7 @@
       %-  ~(rep z-in ~(tx-ids get:page:t page))
       |=  [=tx-id:t effects=(list effect:dk)]
       ^-  (list effect:dk)
-      =/  tx=raw-tx:t  raw-tx:(~(got z-by raw-txs.c.k) tx-id)
+      =/  tx=raw-tx:t  raw-tx:(~(got h-by raw-txs.c.k) tx-id)
       =/  fec=effect:dk  [%gossip %0 %heard-tx tx]
       [fec effects]
     ::

--- a/hoon/apps/dumbnet/inner.hoon
+++ b/hoon/apps/dumbnet/inner.hoon
@@ -163,9 +163,9 @@
             ~
         (~(put z-ju bnb) tx-id block-id)
       ~>  %slog.[0 'load: Indexed blocks by transaction id']
-      =/  rtx=(map tx-id:v0:t *)  raw-txs.c.arg
-      =/  bnb=(map tx-id:v0:t *)  blocks-needed-by
-      =/  excluded-map=(map tx-id:v0:t *)  (~(dif z-by rtx) bnb)
+      =/  rtx=(z-map tx-id:v0:t *)  raw-txs.c.arg
+      =/  bnb=(z-map tx-id:v0:t *)  blocks-needed-by
+      =/  excluded-map=(z-map tx-id:v0:t *)  (~(dif z-by rtx) bnb)
       =/  excluded-txs=(z-set tx-id:v0:t)  ~(key z-by excluded-map)
       =+
         ?:  =(*(z-set tx-id:v0:t) excluded-txs)
@@ -1394,7 +1394,7 @@
           ~>  %slog.[1 'do-pow: Mined for wrong (old) block commitment']
           [~ k]
         ?:  %+  check-target:mine  dig.command
-            (~(got z-by targets.c.k) ~(parent get:page:t candidate-block.m.k))
+            (~(got h-by targets.c.k) ~(parent get:page:t candidate-block.m.k))
           =.  m.k  (set-pow:min prf.command)
           =.  m.k  set-digest:min
           =^  heard-block-effs  k  (heard-block /poke/miner now candidate-block.m.k eny)

--- a/hoon/apps/dumbnet/lib/consensus.hoon
+++ b/hoon/apps/dumbnet/lib/consensus.hoon
@@ -2,7 +2,7 @@
 /=  sp  /common/stark/prover
 /=  mine  /common/pow
 /=  dumb-transact  /common/tx-engine
-/=  *  /common/zoon
+/=  *  /common/h-zoon
 ::
 ::  this library is where _every_ update to the consensus state
 ::  occurs, no matter how minor.
@@ -12,23 +12,23 @@
 ::  assert preconditions, provide reason for failure
 ++  apt
   ^-  (unit @tas)
-  ?.  ~(apt z-by blocks-needed-by.c)  `%inapt-blocks-needed-by
-  ?.  ~(apt z-in excluded-txs.c)  `%inapt-excluded-txs
-  ?.  ~(apt z-by spent-by.c)  `%inapt-spent-by
-  ?.  ~(apt z-by pending-blocks.c)  `%inapt-pending-blocks
-  ?.  ~(apt z-by balance.c)  `%inapt-balance
-  ?.  ~(apt z-by txs.c)  `%inapt-txs
+  ?.  ~(apt h-by blocks-needed-by.c)  `%inapt-blocks-needed-by
+  ?.  ~(apt h-in excluded-txs.c)  `%inapt-excluded-txs
+  ?.  ~(apt h-by spent-by.c)  `%inapt-spent-by
+  ?.  ~(apt h-by pending-blocks.c)  `%inapt-pending-blocks
+  ?.  ~(apt h-by balance.c)  `%inapt-balance
+  ?.  ~(apt h-by txs.c)  `%inapt-txs
   ::  these would take too long but a full semantic verification would include them
-  ::?.  ~(apt z-by raw-txs.c)  `%inapt-raw-txs
-  ::?.  ~(apt z-by blocks.c)  `%inapt-blocks
-  ::?.  ~(apt z-by min-timestamps.c)  `%inapt-min-timestamps
-  ::?.  ~(apt z-by epoch-start.c)  `%inapt-epoch-start
-  ::?.  ~(apt z-by targets.c)  `%inapt-targets
-  ?.  =(excluded-txs.c (~(int z-in excluded-txs.c) ~(key z-by raw-txs.c)))
+  ::?.  ~(apt h-by raw-txs.c)  `%inapt-raw-txs
+  ::?.  ~(apt h-by blocks.c)  `%inapt-blocks
+  ::?.  ~(apt h-by min-timestamps.c)  `%inapt-min-timestamps
+  ::?.  ~(apt h-by epoch-start.c)  `%inapt-epoch-start
+  ::?.  ~(apt h-by targets.c)  `%inapt-targets
+  ?.  =(excluded-txs.c (~(int h-in excluded-txs.c) ~(key h-by raw-txs.c)))
     `%extra-excluded-txs
-  ?.  =(*(z-set tx-id:t) (~(int z-in excluded-txs.c) ~(key z-by blocks-needed-by.c)))
+  ?.  =(*(h-set tx-id:t) (~(int h-in excluded-txs.c) ~(key h-by blocks-needed-by.c)))
     `%excluded-txs-arent
-  ?.  =(excluded-txs.c (~(dif z-in ~(key z-by raw-txs.c)) ~(key z-by blocks-needed-by.c)))
+  ?.  =(excluded-txs.c (~(dif h-in ~(key h-by raw-txs.c)) ~(key h-by blocks-needed-by.c)))
     `%txs-fell-through-cracks
   ~
 ::
@@ -45,9 +45,9 @@
     $(reason %txs-fell-through-cracks)
   ::
       %txs-fell-through-cracks
-    =/  rtx=(z-map tx-id:t *)  raw-txs.c
-    =/  bnb=(z-map tx-id:t *)  blocks-needed-by.c
-    c(excluded-txs ~(key z-by (~(dif z-by rtx) bnb)))
+    =/  rtx=(h-map tx-id:t *)  raw-txs.c
+    =/  bnb=(h-map tx-id:t *)  blocks-needed-by.c
+    c(excluded-txs ~(key h-by (~(dif h-by rtx) bnb)))
   ==
 ::
 ::  check for bad state, repair if necessary
@@ -60,12 +60,12 @@
 ++  has-raw-tx
   |=  tid=tx-id:t
   ^-  ?
-  (~(has z-by raw-txs.c) tid)
+  (~(has h-by raw-txs.c) tid)
 ::
 ++  get-raw-tx
   |=  tid=tx-id:t
   ^-  (unit raw-tx:t)
-  =/  tx  (~(get z-by raw-txs.c) tid)
+  =/  tx  (~(get h-by raw-txs.c) tid)
   ?~  tx  ~  `raw-tx.u.tx
 ::
 ++  got-raw-tx
@@ -122,29 +122,29 @@
   (inputs-in-balance raw get-cur-balance-names)
 ::
 ++  inputs-in-balance
-  |=  [raw=raw-tx:t balance=(z-set nname:t)]
+  |=  [raw=raw-tx:t balance=(h-set nname:t)]
   ^-  ?
   ::  set of inputs required by tx that are not in balance
-  =/  in-balance=(z-set nname:t)
-    (~(dif z-in ~(input-names get:raw-tx:t raw)) balance)
+  =/  in-balance=(h-set nname:t)
+    (~(dif h-in ~(input-names get:raw-tx:t raw)) balance)
   ::  %.y: all inputs in .raw are in balance
   ::  %.n: input(s) in .raw not in balance
-  =(*(z-set nname:t) in-balance)
+  =(*(h-set nname:t) in-balance)
 ::
 ++  get-cur-height
   ^-  page-number:t
-  ~(height get:local-page:t (~(got z-by blocks.c) (need heaviest-block.c)))
+  ~(height get:local-page:t (~(got h-by blocks.c) (need heaviest-block.c)))
 ::
 ++  get-cur-balance
-  ^-  (z-map nname:t nnote:t)
+  ^-  (h-map nname:t nnote:t)
   ?~  heaviest-block.c
     ~>  %slog.[1 'get-cur-balance: No known blocks, balance is empty']
-    *(z-map nname:t nnote:t)
-  (~(got z-by balance.c) u.heaviest-block.c)
+    *(h-map nname:t nnote:t)
+  (~(got h-by balance.c) u.heaviest-block.c)
 ::
 ++  get-cur-balance-names
-  ^-  (z-set nname:t)
-  ~(key z-by get-cur-balance)
+  ^-  (h-set nname:t)
+  ~(key h-by get-cur-balance)
 ::
 ::
 ::  +compute-target: find the new target
@@ -208,11 +208,11 @@
   |=  last-block=block-id:t
   ^-  @
   =/  prev-last-block=block-id:t
-    (~(got z-by epoch-start.c) last-block)
+    (~(got h-by epoch-start.c) last-block)
   =/  epoch-start=@
-    (~(got z-by min-timestamps.c) prev-last-block)
+    (~(got h-by min-timestamps.c) prev-last-block)
   =/  epoch-end=@
-    (~(got z-by min-timestamps.c) last-block)
+    (~(got h-by min-timestamps.c) last-block)
   ~|  "compute-epoch-duration: Time warp attack: Negative epoch duration"
   (sub epoch-end epoch-start)
 ::
@@ -234,7 +234,7 @@
   =?  balance.c  !=(~ balance.acc)
     ::  if balance.acc is empty, this would still add the following to balance.c,
     ::  so we do it conditionally.
-    (~(put z-by balance.c) ~(digest get:page:t pag) balance.acc)
+    (~(put h-by balance.c) ~(digest get:page:t pag) balance.acc)
   =/  cb=coinbase-split:t  ~(coinbase get:page:t pag)
   =/  height=page-number:t  ~(height get:page:t pag)
   =/  coinbases=(list coinbase:t)
@@ -250,20 +250,20 @@
         ::  v1 coinbase only allowed at or after v1-phase
         ?:  (lth height v1-phase.blockchain-constants)
           ~|  %v1-coinbase-before-activation  !!
-        %+  turn  ~(tap z-in ~(key z-by +.cb))
+        %+  turn  ~(tap h-in ~(key z-by +.cb))
         |=  h=hash:t
-        (new:coinbase:t pag (~(put z-in *(z-set hash:t)) h))
+        (new:coinbase:t pag (~(put h-in *(h-set hash:t)) h))
     ==
   =.  balance.c
     %+  roll  coinbases
     |=  [=coinbase:t bal=_balance.c]
-    (~(put z-bi bal) ~(digest get:page:t pag) ~(name get:nnote:t coinbase) coinbase)
+    (~(put h-bi bal) ~(digest get:page:t pag) ~(name get:nnote:t coinbase) coinbase)
   ::  update txs
   ::
   =.  txs.c
-    %-  ~(rep z-by txs.acc)
+    %-  ~(rep h-by txs.acc)
     |=  [[=tx-id:t =tx:t] txs=_txs.c]
-    (~(put z-bi txs) ~(digest get:page:t pag) tx-id tx)
+    (~(put h-bi txs) ~(digest get:page:t pag) tx-id tx)
   ::
   ::  update epoch map. the first block-id in an epoch maps to its parent,
   ::  and each subsequent block maps to the same block-id as the first. this is helpful
@@ -272,30 +272,30 @@
   =.  epoch-start.c
     ?:  =(*page-number:t ~(height get:page:t pag))
       ::  genesis block is also considered the last block of the "0th" epoch.
-      (~(put z-by epoch-start.c) ~(digest get:page:t pag) ~(digest get:page:t pag))
+      (~(put h-by epoch-start.c) ~(digest get:page:t pag) ~(digest get:page:t pag))
     ?:  =(0 ~(epoch-counter get:page:t pag))
-      (~(put z-by epoch-start.c) ~(digest get:page:t pag) ~(parent get:page:t pag))
-    %-  ~(put z-by epoch-start.c)
+      (~(put h-by epoch-start.c) ~(digest get:page:t pag) ~(parent get:page:t pag))
+    %-  ~(put h-by epoch-start.c)
     :-  ~(digest get:page:t pag)
-    (~(got z-by epoch-start.c) ~(parent get:page:t pag))
+    (~(got h-by epoch-start.c) ~(parent get:page:t pag))
   =.  min-timestamps.c  (update-min-timestamps now pag)
   ::
   =.  targets.c
     ?:  =(+(~(epoch-counter get:page:t pag)) blocks-per-epoch:t)
       ::  last block of an epoch means update to target
-      %-  ~(put z-by targets.c)
+      %-  ~(put h-by targets.c)
       :-  ~(digest get:page:t pag)
       (compute-target ~(digest get:page:t pag) ~(target get:page:t pag))
     ?:  =(~(height get:page:t pag) *page-number:t)  ::  genesis block
-      %-  ~(put z-by targets.c)
+      %-  ~(put h-by targets.c)
       [~(digest get:page:t pag) ~(target get:page:t pag)]
     ::  target remains the same throughout an epoch
-    %-  ~(put z-by targets.c)
+    %-  ~(put h-by targets.c)
     :-  ~(digest get:page:t pag)
-    (~(got z-by targets.c) ~(parent get:page:t pag))
+    (~(got h-by targets.c) ~(parent get:page:t pag))
   ::  note we do not update heaviest-block here, since that is conditional
   ::  and the effects emitted depend on whether we do it.
-  ?:  (~(has z-by pending-blocks.c) ~(digest get:page:t pag))
+  ?:  (~(has h-by pending-blocks.c) ~(digest get:page:t pag))
     (accept-pending-block ~(digest get:page:t pag))
   (accept-block pag)
 ::
@@ -322,7 +322,7 @@
   ?.  version-check
     ~&  [%expected-vs-actual version version:(need ~(pow get:page:t pag))]
     [%.n %proof-version-invalid]
-  =/  par=page:t  (to-page:local-page:t (~(got z-by blocks.c) ~(parent get:page:t pag)))
+  =/  par=page:t  (to-page:local-page:t (~(got h-by blocks.c) ~(parent get:page:t pag)))
   ::  this is already checked in +heard-block but is done here again
   ::  to avoid a footgun
   ?.  (check-digest:page:t pag)
@@ -354,7 +354,7 @@
   ::
   =/  check-timestamp=?
     ?&  %+  gte  ~(timestamp get:page:t pag)
-        (~(got z-by min-timestamps.c) ~(parent get:page:t pag))
+        (~(got h-by min-timestamps.c) ~(parent get:page:t pag))
       ::
         (lte ~(timestamp get:page:t pag) (add now-secs max-future-timestamp:t))
     ==
@@ -362,7 +362,7 @@
     [%.n %page-timestamp-invalid]
   ::
   ::  check target
-  ?.  =(~(target get:page:t pag) (~(got z-by targets.c) ~(parent get:page:t pag)))
+  ?.  =(~(target get:page:t pag) (~(got h-by targets.c) ~(parent get:page:t pag)))
     [%.n %page-target-invalid]
   ::
   ::  check height
@@ -418,13 +418,14 @@
   ?.  (check-size pag)
     ~>  %slog.[1 (cat 3 'validate-page-with-txs: Block too large: ' digest-b58)]
     [%.n %block-too-large]
-  =/  raw-tx-set=(z-set (unit raw-tx:t))
-    (~(run z-in ~(tx-ids get:page:t pag)) |=(=tx-id:t (get-raw-tx tx-id)))
-  =/  raw-tx-list=(list (unit raw-tx:t))  ~(tap z-in raw-tx-set)
+  =/  tx-id-list=(list tx-id:t)
+    ~(tap h-in ~(tx-ids get:page:t pag))
+  =/  raw-tx-list=(list (unit raw-tx:t))
+    (turn tx-id-list |=(=tx-id:t (get-raw-tx tx-id)))
   :: initialize balance transfer accumulator with parent block's balance
   =/  acc=tx-acc:t
     %+  new:tx-acc:t
-      (~(get z-by balance.c) ~(parent get:page:t pag))
+      (~(get h-by balance.c) ~(parent get:page:t pag))
     ~(height get:page:t pag)
   ::
   ::  test to see that the input notes for all transactions
@@ -490,7 +491,7 @@
     c(heaviest-block (some ~(digest get:page:t pag)))
   ::  > rather than >= since we take the first heaviest block we've heard
   ?:  %+  compare-heaviness:page:t  pag
-      (~(got z-by blocks.c) (need heaviest-block.c))
+      (~(got h-by blocks.c) (need heaviest-block.c))
     =/  log-message
       %+  rap  3
       :~  'update-heaviest: '
@@ -515,12 +516,12 @@
 ++  get-elders
   |=  [d=derived-state:dk bid=block-id:t]
   ^-  (unit [page-number:t (list block-id:t)])
-  =/  block  (~(get z-by blocks.c) bid)
+  =/  block  (~(get h-by blocks.c) bid)
   ?~  block
     ~
   =/  unit-height=(unit page-number:t)
     ?~  heaviest-block.c  `0
-    =/  heaviest-block  (~(get z-by blocks.c) u.heaviest-block.c)
+    =/  heaviest-block  (~(get h-by blocks.c) u.heaviest-block.c)
     ?~  heaviest-block  ~
     `(min ~(height get:local-page:t u.heaviest-block) ~(height get:local-page:t u.block))
   ?~  unit-height  ~
@@ -543,7 +544,7 @@
 ::
 ++  update-min-timestamps
   |=  [now=@da pag=page:t]
-  ^-  (z-map block-id:t @)
+  ^-  (h-map block-id:t @)
   =/  min-timestamp=@
     ::  get timestamps of up to N=min-past-blocks prior blocks.
     =|  prev-timestamps=(list @)
@@ -560,10 +561,10 @@
       (median:t prev-timestamps)
     %=  $
       b          (dec b)
-      cur-block  (to-page:local-page:t (~(got z-by blocks.c) ~(parent get:page:t cur-block)))
+      cur-block  (to-page:local-page:t (~(got h-by blocks.c) ~(parent get:page:t cur-block)))
     ==
   ::
-  (~(put z-by min-timestamps.c) ~(digest get:page:t pag) min-timestamp)
+  (~(put h-by min-timestamps.c) ~(digest get:page:t pag) min-timestamp)
 ::
 ::::  pending block and tx functionality
 ::
@@ -572,13 +573,13 @@
 ++  accept-block
   |=  pag=page:t
   ^-  consensus-state:dk
-  ?<  (~(has z-by blocks.c) ~(digest get:page:t pag))
-  ?<  (~(has z-by pending-blocks.c) ~(digest get:page:t pag))
-  =.  blocks.c  (~(put z-by blocks.c) ~(digest get:page:t pag) (to-local-page:page:t pag))
-  %-  ~(rep z-in ~(tx-ids get:page:t pag))
+  ?<  (~(has h-by blocks.c) ~(digest get:page:t pag))
+  ?<  (~(has h-by pending-blocks.c) ~(digest get:page:t pag))
+  =.  blocks.c  (~(put h-by blocks.c) ~(digest get:page:t pag) (to-local-page:page:t pag))
+  %-  ~(rep h-in ~(tx-ids get:page:t pag))
   |=  [=tx-id:t c=_c]
-  =.  blocks-needed-by.c  (~(put z-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
-  =.  excluded-txs.c  (~(del z-in excluded-txs.c) tx-id)
+  =.  blocks-needed-by.c  (~(put h-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
+  =.  excluded-txs.c  (~(del h-in excluded-txs.c) tx-id)
   c
 ::
 ::  add a block which is waiting on transactions to pending state.
@@ -587,57 +588,57 @@
 ++  add-pending-block
   |=  pag=page:t
   ^-  [(list tx-id:t) consensus-state:dk]
-  ?<  (~(has z-by blocks.c) ~(digest get:page:t pag))
-  ?<  (~(has z-by pending-blocks.c) ~(digest get:page:t pag))
-  =/  needed=(z-set tx-id:t)
-    %-  ~(rep z-in ~(tx-ids get:page:t pag))
-    |=  [=tx-id:t needed=(z-set tx-id:t)]
-    ?.  (~(has z-by raw-txs.c) tx-id)
-      (~(put z-in needed) tx-id)
+  ?<  (~(has h-by blocks.c) ~(digest get:page:t pag))
+  ?<  (~(has h-by pending-blocks.c) ~(digest get:page:t pag))
+  =/  needed=(h-set tx-id:t)
+    %-  ~(rep h-in ~(tx-ids get:page:t pag))
+    |=  [=tx-id:t needed=(h-set tx-id:t)]
+    ?.  (~(has h-by raw-txs.c) tx-id)
+      (~(put h-in needed) tx-id)
     needed
-  ?:  =(*(z-set tx-id:t) needed)
+  ?:  =(*(h-set tx-id:t) needed)
     [~ c] :: not missing any transactions
-  =.  pending-blocks.c  (~(put z-by pending-blocks.c) ~(digest get:page:t pag) [pag get-cur-height])
+  =.  pending-blocks.c  (~(put h-by pending-blocks.c) ~(digest get:page:t pag) [pag get-cur-height])
   =.  c
-    %-  ~(rep z-in ~(tx-ids get:page:t pag))
+    %-  ~(rep h-in ~(tx-ids get:page:t pag))
     |=  [=tx-id:t c=_c]
-    =.  blocks-needed-by.c  (~(put z-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
-    =.  excluded-txs.c  (~(del z-in excluded-txs.c) tx-id)
+    =.  blocks-needed-by.c  (~(put h-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
+    =.  excluded-txs.c  (~(del h-in excluded-txs.c) tx-id)
     c
-  [~(tap z-in needed) c]
+  [~(tap h-in needed) c]
 ::
 ::  reject a pending block
 ++  reject-pending-block
   |=  =block-id:t
   ^-  consensus-state:dk
   ::  block must be pending
-  ?<  (~(has z-by blocks.c) block-id)
-  =/  pag  page:(~(got z-by pending-blocks.c) block-id)
+  ?<  (~(has h-by blocks.c) block-id)
+  =/  pag  page:(~(got h-by pending-blocks.c) block-id)
   =.  c
-    %-  ~(rep z-by ~(tx-ids get:page:t pag))
+    %-  ~(rep h-by ~(tx-ids get:page:t pag))
     |=  [=tx-id:t c=_c]
-    =.  blocks-needed-by.c  (~(del z-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
+    =.  blocks-needed-by.c  (~(del h-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
     =?  excluded-txs.c
-        ?&  ?!((~(has z-by blocks-needed-by.c) tx-id))  ::  not in blocks-needed-by
-            (~(has z-by raw-txs.c) tx-id)               ::  but in raw-txs
+        ?&  ?!((~(has h-by blocks-needed-by.c) tx-id))  ::  not in blocks-needed-by
+            (~(has h-by raw-txs.c) tx-id)               ::  but in raw-txs
         ==
-      (~(put z-in excluded-txs.c) tx-id)
+      (~(put h-in excluded-txs.c) tx-id)
     c
-  =.  pending-blocks.c  (~(del z-by pending-blocks.c) ~(digest get:page:t pag))
+  =.  pending-blocks.c  (~(del h-by pending-blocks.c) ~(digest get:page:t pag))
   c
 ::
 ::  missing transaction ids from pending blocks
 ++  missing-tx-ids
   ^-  (list tx-id:t)
-  %~  tap  z-in
-  ^-  (z-set tx-id:t)
-  %-  ~(rep z-by pending-blocks.c)
-  |=  [[block-id:t pag=page:t *] all=(z-set tx-id:t)]
-  ^-  (z-set tx-id:t)
-  %-  ~(rep z-in ~(tx-ids get:page:t pag))
+  %~  tap  h-in
+  ^-  (h-set tx-id:t)
+  %-  ~(rep h-by pending-blocks.c)
+  |=  [[block-id:t pag=page:t *] all=(h-set tx-id:t)]
+  ^-  (h-set tx-id:t)
+  %-  ~(rep h-in ~(tx-ids get:page:t pag))
   |=  [=tx-id:t all=_all]
-  ?.  (~(has z-by raw-txs.c) tx-id)
-    (~(put z-in all) tx-id)
+  ?.  (~(has h-by raw-txs.c) tx-id)
+    (~(put h-in all) tx-id)
   all
 ::
 ::  move a block from pending-blocks to blocks
@@ -645,10 +646,10 @@
   |=  =block-id:t
   ^-  consensus-state:dk
   ::  block must be pending
-  ?<  (~(has z-by blocks.c) block-id)
-  =/  pag  page:(~(got z-by pending-blocks.c) block-id)
-  =.  pending-blocks.c  (~(del z-by pending-blocks.c) ~(digest get:page:t pag))
-  =.  blocks.c  (~(put z-by blocks.c) block-id (to-local-page:page:t pag))
+  ?<  (~(has h-by blocks.c) block-id)
+  =/  pag  page:(~(got h-by pending-blocks.c) block-id)
+  =.  pending-blocks.c  (~(del h-by pending-blocks.c) ~(digest get:page:t pag))
+  =.  blocks.c  (~(put h-by blocks.c) block-id (to-local-page:page:t pag))
   c
 ::
 ::  list of pending blocks which are lower than the minimum retention height
@@ -658,12 +659,12 @@
   ?~  retain
     ~
   ?~  heaviest-block.c  ~
-  =/  pag=page:t  (to-page:local-page:t (~(got z-by blocks.c) u.heaviest-block.c))
+  =/  pag=page:t  (to-page:local-page:t (~(got h-by blocks.c) u.heaviest-block.c))
   =/  height  ~(height get:page:t pag)
   ?:  (lth height u.retain)
     ~
   =/  min-height  (sub height u.retain)
-  %-  ~(rep z-by pending-blocks.c)
+  %-  ~(rep h-by pending-blocks.c)
   |=  [[=block-id:t =page:t heard-at=@] dropable=(list block-id:t)]
   ?:  (lte heard-at min-height)
     [block-id dropable]
@@ -681,48 +682,48 @@
 ++  inputs-spent
   |=  =raw-tx:t
   ^-  ?
-  =/  input-names=(z-set nname:t)
+  =/  input-names=(h-set nname:t)
     ~(input-names get:raw-tx:t raw-tx)
-  %-  ~(any z-in input-names)
-  ~(has z-by spent-by.c)
+  %-  ~(any h-in input-names)
+  ~(has h-by spent-by.c)
 ::
 ::  Is the transaction needed by a block?
 ++  needed-by-block
   |=  =tx-id:t
   ^-  ?
-  (~(has z-by blocks-needed-by.c) tx-id)
+  (~(has h-by blocks-needed-by.c) tx-id)
 ::
 ::  add an already-validated raw transaction, producing a list of blocks ready to validate
 ++  add-raw-tx
   |=  =raw-tx:t
   ^-  [(list block-id:t) consensus-state:dk]
   =/  =tx-id:t  ~(id get:raw-tx:t raw-tx)
-  ?<  (~(has z-by raw-txs.c) tx-id)
-  =.  raw-txs.c  (~(put z-by raw-txs.c) tx-id [raw-tx get-cur-height])
-  =/  input-names=(z-set nname:t)  ~(input-names get:raw-tx:t raw-tx)
+  ?<  (~(has h-by raw-txs.c) tx-id)
+  =.  raw-txs.c  (~(put h-by raw-txs.c) tx-id [raw-tx get-cur-height])
+  =/  input-names=(h-set nname:t)  ~(input-names get:raw-tx:t raw-tx)
   =.  spent-by.c
-    %-  ~(rep z-in input-names)
+    %-  ~(rep h-in input-names)
     |=  [=nname:t sb=_spent-by.c]
-    (~(put z-ju sb) nname tx-id)
-  =/  bnb  (~(get z-ju blocks-needed-by.c) tx-id)
-  ?:  =(*(z-set block-id:t) bnb)
-    =.  excluded-txs.c  (~(put z-in excluded-txs.c) tx-id)
+    (~(put h-ju sb) nname tx-id)
+  =/  bnb  (~(get h-ju blocks-needed-by.c) tx-id)
+  ?:  =(*(h-set block-id:t) bnb)
+    =.  excluded-txs.c  (~(put h-in excluded-txs.c) tx-id)
     [~ c]
   =/  ready-blocks=(list block-id:t)
-    %-  ~(rep z-in bnb)
+    %-  ~(rep h-in bnb)
     |=  [=block-id:t ready=(list block-id:t)]
-    =/  pending  (~(get z-by pending-blocks.c) block-id)
+    =/  pending  (~(get h-by pending-blocks.c) block-id)
     ?~  pending  ready
     =/  pag  page.u.pending
     =/  needed
-      %-  ~(rep z-in ~(tx-ids get:page:t pag))
-      |=  [=tx-id:t needed=(z-set tx-id:t)]
-      ^-  (z-set tx-id:t)
-      ?.  (~(has z-by raw-txs.c) tx-id)
-        (~(put z-in needed) tx-id)
+      %-  ~(rep h-in ~(tx-ids get:page:t pag))
+      |=  [=tx-id:t needed=(h-set tx-id:t)]
+      ^-  (h-set tx-id:t)
+      ?.  (~(has h-by raw-txs.c) tx-id)
+        (~(put h-in needed) tx-id)
       needed
     ::  if the block is ready, add it to the ready list
-    ?:  =(*(z-set tx-id:t) needed)
+    ?:  =(*(h-set tx-id:t) needed)
       [block-id ready]
     ready
   [ready-blocks c]
@@ -731,46 +732,46 @@
 ++  drop-tx
   |=  =tx-id:t
   ^-  consensus-state:dk
-  ?<  (~(has z-by blocks-needed-by.c) tx-id)
-  ?>  (~(has z-in excluded-txs.c) tx-id)
-  =/  raw-tx  raw-tx:(~(got z-by raw-txs.c) tx-id)
-  =.  raw-txs.c  (~(del z-by raw-txs.c) tx-id)
-  =.  excluded-txs.c  (~(del z-in excluded-txs.c) tx-id)
+  ?<  (~(has h-by blocks-needed-by.c) tx-id)
+  ?>  (~(has h-in excluded-txs.c) tx-id)
+  =/  raw-tx  raw-tx:(~(got h-by raw-txs.c) tx-id)
+  =.  raw-txs.c  (~(del h-by raw-txs.c) tx-id)
+  =.  excluded-txs.c  (~(del h-in excluded-txs.c) tx-id)
   =.  spent-by.c
-    %-  ~(rep z-in ~(input-names get:raw-tx:t raw-tx))
+    %-  ~(rep h-in ~(input-names get:raw-tx:t raw-tx))
     |=  [=nname:t sb=_spent-by.c]
-    (~(del z-ju sb) nname ~(id get:raw-tx:t raw-tx))
+    (~(del h-ju sb) nname ~(id get:raw-tx:t raw-tx))
   c
 ::
 ::  transactions which may be dropped (excluded and lower than minimum retention height)
 ++  dropable-txs
   |=  retain=(unit @)
-  ^-  (z-set tx-id:t)
+  ^-  (h-set tx-id:t)
   ?~  heaviest-block.c  ~
-  =/  height  ~(height get:local-page:t (~(got z-by blocks.c) u.heaviest-block.c))
-  =/  spent=(z-set tx-id:t)
-    %-  ~(rep z-in excluded-txs.c)
-    |=  [=tx-id:t spent=(z-set tx-id:t)]
-    ^-  (z-set tx-id:t)
-    =/  raw-tx  raw-tx:(~(got z-by raw-txs.c) tx-id)
+  =/  height  ~(height get:local-page:t (~(got h-by blocks.c) u.heaviest-block.c))
+  =/  spent=(h-set tx-id:t)
+    %-  ~(rep h-in excluded-txs.c)
+    |=  [=tx-id:t spent=(h-set tx-id:t)]
+    ^-  (h-set tx-id:t)
+    =/  raw-tx  raw-tx:(~(got h-by raw-txs.c) tx-id)
     ?.  (inputs-in-heaviest-balance raw-tx)
-      (~(put z-in spent) tx-id)
+      (~(put h-in spent) tx-id)
     spent
   ?~  retain  spent
   ?:  (lth height u.retain)  spent
   =/  min-height  (sub height u.retain)
-  %-  ~(rep z-in excluded-txs.c)
+  %-  ~(rep h-in excluded-txs.c)
   |=  [=tx-id:t dropable=_spent]
-  =/  [=raw-tx:t heard-at=@]  (~(got z-by raw-txs.c) tx-id)
+  =/  [=raw-tx:t heard-at=@]  (~(got h-by raw-txs.c) tx-id)
   ?:  (lte heard-at min-height)
-    (~(put z-in dropable) tx-id)
+    (~(put h-in dropable) tx-id)
   dropable
 ::
 ::  drop all dropable transactions
 ++  drop-dropable-txs
   |=  retain=(unit @)
   ^-  consensus-state:dk
-  %-  ~(rep z-in (dropable-txs retain))
+  %-  ~(rep h-in (dropable-txs retain))
   |=  [=tx-id:t con=_c]
   =.  c  con
   (drop-tx tx-id)

--- a/hoon/apps/dumbnet/lib/consensus.hoon
+++ b/hoon/apps/dumbnet/lib/consensus.hoon
@@ -126,7 +126,7 @@
   ^-  ?
   ::  set of inputs required by tx that are not in balance
   =/  in-balance=(h-set nname:t)
-    (~(dif h-in ~(input-names get:raw-tx:t raw)) balance)
+    (~(dif h-in (zh-silt ~(input-names get:raw-tx:t raw))) balance)
   ::  %.y: all inputs in .raw are in balance
   ::  %.n: input(s) in .raw not in balance
   =(*(h-set nname:t) in-balance)
@@ -250,9 +250,9 @@
         ::  v1 coinbase only allowed at or after v1-phase
         ?:  (lth height v1-phase.blockchain-constants)
           ~|  %v1-coinbase-before-activation  !!
-        %+  turn  ~(tap h-in ~(key z-by +.cb))
+        %+  turn  ~(tap z-in ~(key z-by +.cb))
         |=  h=hash:t
-        (new:coinbase:t pag (~(put h-in *(h-set hash:t)) h))
+        (new:coinbase:t pag (~(put z-in *(z-set hash:t)) h))
     ==
   =.  balance.c
     %+  roll  coinbases
@@ -419,7 +419,7 @@
     ~>  %slog.[1 (cat 3 'validate-page-with-txs: Block too large: ' digest-b58)]
     [%.n %block-too-large]
   =/  tx-id-list=(list tx-id:t)
-    ~(tap h-in ~(tx-ids get:page:t pag))
+    ~(tap z-in ~(tx-ids get:page:t pag))
   =/  raw-tx-list=(list (unit raw-tx:t))
     (turn tx-id-list |=(=tx-id:t (get-raw-tx tx-id)))
   :: initialize balance transfer accumulator with parent block's balance
@@ -576,7 +576,7 @@
   ?<  (~(has h-by blocks.c) ~(digest get:page:t pag))
   ?<  (~(has h-by pending-blocks.c) ~(digest get:page:t pag))
   =.  blocks.c  (~(put h-by blocks.c) ~(digest get:page:t pag) (to-local-page:page:t pag))
-  %-  ~(rep h-in ~(tx-ids get:page:t pag))
+  %-  ~(rep z-in ~(tx-ids get:page:t pag))
   |=  [=tx-id:t c=_c]
   =.  blocks-needed-by.c  (~(put h-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
   =.  excluded-txs.c  (~(del h-in excluded-txs.c) tx-id)
@@ -591,7 +591,7 @@
   ?<  (~(has h-by blocks.c) ~(digest get:page:t pag))
   ?<  (~(has h-by pending-blocks.c) ~(digest get:page:t pag))
   =/  needed=(h-set tx-id:t)
-    %-  ~(rep h-in ~(tx-ids get:page:t pag))
+    %-  ~(rep z-in ~(tx-ids get:page:t pag))
     |=  [=tx-id:t needed=(h-set tx-id:t)]
     ?.  (~(has h-by raw-txs.c) tx-id)
       (~(put h-in needed) tx-id)
@@ -600,7 +600,7 @@
     [~ c] :: not missing any transactions
   =.  pending-blocks.c  (~(put h-by pending-blocks.c) ~(digest get:page:t pag) [pag get-cur-height])
   =.  c
-    %-  ~(rep h-in ~(tx-ids get:page:t pag))
+    %-  ~(rep z-in ~(tx-ids get:page:t pag))
     |=  [=tx-id:t c=_c]
     =.  blocks-needed-by.c  (~(put h-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
     =.  excluded-txs.c  (~(del h-in excluded-txs.c) tx-id)
@@ -615,7 +615,7 @@
   ?<  (~(has h-by blocks.c) block-id)
   =/  pag  page:(~(got h-by pending-blocks.c) block-id)
   =.  c
-    %-  ~(rep h-by ~(tx-ids get:page:t pag))
+    %-  ~(rep z-by ~(tx-ids get:page:t pag))
     |=  [=tx-id:t c=_c]
     =.  blocks-needed-by.c  (~(del h-ju blocks-needed-by.c) tx-id ~(digest get:page:t pag))
     =?  excluded-txs.c
@@ -635,7 +635,7 @@
   %-  ~(rep h-by pending-blocks.c)
   |=  [[block-id:t pag=page:t *] all=(h-set tx-id:t)]
   ^-  (h-set tx-id:t)
-  %-  ~(rep h-in ~(tx-ids get:page:t pag))
+  %-  ~(rep z-in ~(tx-ids get:page:t pag))
   |=  [=tx-id:t all=_all]
   ?.  (~(has h-by raw-txs.c) tx-id)
     (~(put h-in all) tx-id)
@@ -683,7 +683,7 @@
   |=  =raw-tx:t
   ^-  ?
   =/  input-names=(h-set nname:t)
-    ~(input-names get:raw-tx:t raw-tx)
+    (zh-silt ~(input-names get:raw-tx:t raw-tx))
   %-  ~(any h-in input-names)
   ~(has h-by spent-by.c)
 ::
@@ -700,9 +700,9 @@
   =/  =tx-id:t  ~(id get:raw-tx:t raw-tx)
   ?<  (~(has h-by raw-txs.c) tx-id)
   =.  raw-txs.c  (~(put h-by raw-txs.c) tx-id [raw-tx get-cur-height])
-  =/  input-names=(h-set nname:t)  ~(input-names get:raw-tx:t raw-tx)
+  =/  input-names=(z-set nname:t)  ~(input-names get:raw-tx:t raw-tx)
   =.  spent-by.c
-    %-  ~(rep h-in input-names)
+    %-  ~(rep z-in input-names)
     |=  [=nname:t sb=_spent-by.c]
     (~(put h-ju sb) nname tx-id)
   =/  bnb  (~(get h-ju blocks-needed-by.c) tx-id)
@@ -716,7 +716,7 @@
     ?~  pending  ready
     =/  pag  page.u.pending
     =/  needed
-      %-  ~(rep h-in ~(tx-ids get:page:t pag))
+      %-  ~(rep z-in ~(tx-ids get:page:t pag))
       |=  [=tx-id:t needed=(h-set tx-id:t)]
       ^-  (h-set tx-id:t)
       ?.  (~(has h-by raw-txs.c) tx-id)
@@ -738,7 +738,7 @@
   =.  raw-txs.c  (~(del h-by raw-txs.c) tx-id)
   =.  excluded-txs.c  (~(del h-in excluded-txs.c) tx-id)
   =.  spent-by.c
-    %-  ~(rep h-in ~(input-names get:raw-tx:t raw-tx))
+    %-  ~(rep z-in ~(input-names get:raw-tx:t raw-tx))
     |=  [=nname:t sb=_spent-by.c]
     (~(del h-ju sb) nname ~(id get:raw-tx:t raw-tx))
   c

--- a/hoon/apps/dumbnet/lib/derived.hoon
+++ b/hoon/apps/dumbnet/lib/derived.hoon
@@ -1,6 +1,6 @@
 /=  dk  /apps/dumbnet/lib/types
 /=  dumb-transact  /common/tx-engine
-/=  *  /common/zoon
+/=  *  /common/h-zoon
 ::
 |_  [d=derived-state:dk =blockchain-constants:dumb-transact]
 +*  t  ~(. dumb-transact blockchain-constants)
@@ -14,7 +14,7 @@
   =/  heaviest-page=page:t
     ?:  =(~ heaviest-block.c)
       pag  :: genesis block
-    (to-page:local-page:t (~(got z-by blocks.c) (need heaviest-block.c)))
+    (to-page:local-page:t (~(got h-by blocks.c) (need heaviest-block.c)))
   =/  next-parent=block-id:t    ~(digest get:page:t heaviest-page)
   =/  next-height=page-number:t  ~(height get:page:t heaviest-page)
   |-
@@ -31,7 +31,7 @@
     d
   %=  $
     next-height   (dec next-height)
-    next-parent  ~(parent get:local-page:t (~(got z-by blocks.c) next-parent))
+    next-parent  ~(parent get:local-page:t (~(got h-by blocks.c) next-parent))
   ==
 ++  update-highest
   |=  height=page-number:t
@@ -51,7 +51,7 @@
   ^-  (unit ?)
   ?~  genesis-seal.c
     ?^  genesis-id=(~(get z-by heaviest-chain.d) 0)
-      =+  genesis=(~(get z-by blocks.c) u.genesis-id)
+      =+  genesis=(~(get h-by blocks.c) u.genesis-id)
       ?~  genesis
         ~
       `=((hash:page-msg:t ~(msg get:local-page:t u.genesis)) realnet-genesis-msg:dk)

--- a/hoon/apps/dumbnet/lib/miner.hoon
+++ b/hoon/apps/dumbnet/lib/miner.hoon
@@ -1,7 +1,7 @@
 /=  dk  /apps/dumbnet/lib/types
 /=  sp  /common/stark/prover
 /=  dumb-transact  /common/tx-engine
-/=  *  /common/zoon
+/=  *  /common/h-zoon
 ::
 :: everything to do with mining and mining state
 ::
@@ -50,35 +50,35 @@
   max-block-size:t
 ::
 ::  grab all raw-txs that could possibly be included in block.
-::  note that this set could include txs that are not spendable
+::  note that this map could include txs that are not spendable
 ::  from the current heaviest balance. we rely on the logic inside
 ::  of process:tx-acc to catch these txs and reject them.
 ++  candidate-txs
   |=  c=consensus-state:dk
-  ^-  (z-set raw-tx:t)
+  ^-  (h-map tx-id:t raw-tx:t)
   |^
-    %-  ~(rep z-in candidate-tx-ids)
-    |=  [=tx-id:t txs=(set raw-tx:t)]
-    =/  raw  raw-tx:(~(got z-by raw-txs.c) tx-id)
-    (~(put z-in txs) raw)
+    %-  ~(rep h-in candidate-tx-ids)
+    |=  [=tx-id:t txs=(h-map tx-id:t raw-tx:t)]
+    =/  raw  raw-tx:(~(got h-by raw-txs.c) tx-id)
+    (~(put h-by txs) [tx-id raw])
   ::
   ::  union of excluded tx-ids and pending block tx ids
   ::  excluding tx-ids already included in candidate block
   ++  candidate-tx-ids
-    %-  %~  dif  z-in
-        (~(uni z-in excluded-txs.c) pending-block-tx-ids)
+    %-  %~  dif  h-in
+        (~(uni h-in excluded-txs.c) pending-block-tx-ids)
     ~(tx-ids get:page:t candidate-block.m)
   ::
   ::  set of available raw-txs from pending blocks
   ++  pending-block-tx-ids
-    ^-  (z-set tx-id:t)
-    %-  ~(rep z-by pending-blocks.c)
-    |=  [[block-id:t pag=page:t *] all=(z-set tx-id:t)]
-    ^-  (z-set tx-id:t)
-    %-  ~(rep z-in ~(tx-ids get:page:t pag))
+    ^-  (h-set tx-id:t)
+    %-  ~(rep h-by pending-blocks.c)
+    |=  [[block-id:t pag=page:t *] all=(h-set tx-id:t)]
+    ^-  (h-set tx-id:t)
+    %-  ~(rep h-in ~(tx-ids get:page:t pag))
     |=  [=tx-id:t all=_all]
-    ?:  (~(has z-by raw-txs.c) tx-id)
-      (~(put z-in all) tx-id)
+    ?:  (~(has h-by raw-txs.c) tx-id)
+      (~(put h-in all) tx-id)
     all
   --
 ::
@@ -116,10 +116,15 @@
   ^-  mining-state:dk
   ::  if the mining pubkey is not set, do nothing
   ?:  no-keys-set  m
-  %-  ~(rep z-in (candidate-txs c))
-  |=  [raw=raw-tx:t min=_m]
-  =.  m  min
-  (heard-new-tx raw)
+  !!
+  :: %-  ~(rep h-by (candidate-txs c))
+  :: |=  [[=tx-id:t raw=raw-tx:t] min=_m]
+  :: =.  m  min
+  :: (heard-new-tx raw)
+  :: |=  [[=noun-digest:tip5:z raw=raw-tx:t] min=_m]
+  :: !!
+  :: =.  m  min
+  :: (heard-new-tx raw)
 ::
 ::
 ::  +heard-new-tx: potentially changes candidate block in reaction to a raw-tx
@@ -138,7 +143,7 @@
   ?:  no-keys-set  m
   ::
   ::  if the transaction is already in the candidate block, do nothing
-  ?:  (~(has z-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
+  ?:  (~(has h-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
     m
   :: ::  check to see if block is valid with tx - this checks whether the inputs
   :: ::  exist, whether the new size will exceed block size, and whether timelocks
@@ -163,7 +168,7 @@
     m
   =/  old-mining-state  m
   ::  we can add tx to candidate-block
-  =/  new-tx-ids  (~(put z-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
+  =/  new-tx-ids  (~(put h-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
   =.  candidate-block.m
     ?^  -.candidate-block.m
       candidate-block.m(tx-ids new-tx-ids)
@@ -266,7 +271,7 @@
         (to-b58:hash:t u.heaviest-block.c)
     ==
   ~>  %slog.[0 log-message]
-  =/  parent-local=local-page:t  (~(got z-by blocks.c) u.heaviest-block.c)
+  =/  parent-local=local-page:t  (~(got h-by blocks.c) u.heaviest-block.c)
   =/  parent=page:t  (to-page:local-page:t parent-local)
   =.  candidate-block.m
     ?^  -.parent
@@ -274,13 +279,13 @@
       ::    if candidate height is less than cutoff, use v0 new-candidate with v0 shares
       ::    otherwise use v1 new-candidate with v1 shares
       ?:  (lth +(height.parent) v1-phase.blockchain-constants)
-        (new-candidate:v0:page:t parent now (~(got z-by targets.c) u.heaviest-block.c) v0-shares.m)
-      (new-candidate:page:t parent now (~(got z-by targets.c) u.heaviest-block.c) shares.m)
+        (new-candidate:v0:page:t parent now (~(got h-by targets.c) u.heaviest-block.c) v0-shares.m)
+      (new-candidate:page:t parent now (~(got h-by targets.c) u.heaviest-block.c) shares.m)
     ::  v1 parent - use v1 new-candidate with v1 shares
-    (new-candidate:page:t parent now (~(got z-by targets.c) u.heaviest-block.c) shares.m)
+    (new-candidate:page:t parent now (~(got h-by targets.c) u.heaviest-block.c) shares.m)
   =.  candidate-acc.m
     %+  new:tx-acc:t
-      (~(get z-by balance.c) u.heaviest-block.c)
+      (~(get h-by balance.c) u.heaviest-block.c)
     ~(height get:page:t candidate-block.m)
   ::
   ::  roll over the candidate txs and try to include them in the new candidate block

--- a/hoon/apps/dumbnet/lib/miner.hoon
+++ b/hoon/apps/dumbnet/lib/miner.hoon
@@ -67,7 +67,7 @@
   ++  candidate-tx-ids
     %-  %~  dif  h-in
         (~(uni h-in excluded-txs.c) pending-block-tx-ids)
-    ~(tx-ids get:page:t candidate-block.m)
+    (zh-silt ~(tx-ids get:page:t candidate-block.m))
   ::
   ::  set of available raw-txs from pending blocks
   ++  pending-block-tx-ids
@@ -75,7 +75,7 @@
     %-  ~(rep h-by pending-blocks.c)
     |=  [[block-id:t pag=page:t *] all=(h-set tx-id:t)]
     ^-  (h-set tx-id:t)
-    %-  ~(rep h-in ~(tx-ids get:page:t pag))
+    %-  ~(rep h-in (zh-silt ~(tx-ids get:page:t pag)))
     |=  [=tx-id:t all=_all]
     ?:  (~(has h-by raw-txs.c) tx-id)
       (~(put h-in all) tx-id)
@@ -143,7 +143,7 @@
   ?:  no-keys-set  m
   ::
   ::  if the transaction is already in the candidate block, do nothing
-  ?:  (~(has h-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
+  ?:  (~(has z-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
     m
   :: ::  check to see if block is valid with tx - this checks whether the inputs
   :: ::  exist, whether the new size will exceed block size, and whether timelocks
@@ -168,7 +168,7 @@
     m
   =/  old-mining-state  m
   ::  we can add tx to candidate-block
-  =/  new-tx-ids  (~(put h-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
+  =/  new-tx-ids  (~(put z-in ~(tx-ids get:page:t candidate-block.m)) tx-id)
   =.  candidate-block.m
     ?^  -.candidate-block.m
       candidate-block.m(tx-ids new-tx-ids)

--- a/hoon/apps/dumbnet/lib/types.hoon
+++ b/hoon/apps/dumbnet/lib/types.hoon
@@ -1,4 +1,4 @@
-/=  *   /common/zoon
+/=  *   /common/h-zoon
 /=  zeke  /common/zeke
 /=  w   /common/wrapper
 /=  dt  /common/tx-engine
@@ -15,6 +15,7 @@
       kernel-state-4
       kernel-state-5
       kernel-state-6
+      kernel-state-7
   ==
 ::
 +$  kernel-state-0
@@ -90,7 +91,17 @@
       constants=blockchain-constants:v1:dt
   ==
 ::
-+$  kernel-state  kernel-state-6
++$  kernel-state-7
+  $:  %7
+      c=consensus-state-7
+      a=admin-state-7
+      m=mining-state-7
+    ::
+      d=derived-state-7
+      constants=blockchain-constants:v1:dt
+  ==
+::
++$  kernel-state  kernel-state-7
 ::
 +$  consensus-state-0
   $+  consensus-state-0
@@ -231,7 +242,51 @@
     ==
   ==
 ::
-+$  consensus-state  consensus-state-6
++$  consensus-state-7
+  $+  consensus-state-7
+  ::
+  ::  indexes and not-fully-validated state
+  $:
+    $:
+    :: keys in raw-txs must be in EXACTLY ONE OF blocks-needed-by or excluded-txs
+        blocks-needed-by=(h-jug tx-id:dt block-id:dt) :: dependencies
+        excluded-txs=(h-set tx-id:dt) :: transactions unneeded by any block
+    ::
+    ::  every tx-id in spent-by must be in raw-txs and vice-versa
+        spent-by=(h-jug nname:dt tx-id:dt)
+    ::
+        pending-blocks=(h-map block-id:dt [=page:dt heard-at=@])  :: pending blocks
+    ==
+  ::
+  ::  core consensus state
+    $:  balance=(h-mip block-id:dt nname:dt nnote:dt)
+        txs=(h-mip block-id:dt tx-id:dt tx:dt) ::  fully validated transactions
+      ::
+      :: keys in raw-txs must be in EXACTLY ONE OF blocks-needed-by or excluded-txs
+        raw-txs=(h-map tx-id:dt [=raw-tx:dt heard-at=@]) :: raw transactions
+      ::
+        blocks=(h-map block-id:dt local-page:dt)  ::  fully validated blocks
+      ::
+        heaviest-block=(unit block-id:dt) ::  most recent heaviest block
+      ::
+      ::  min timestamp of block that is a child of this block
+        min-timestamps=(h-map block-id:dt @)
+      ::  this map is used to calculate epoch duration. it is a map of each
+      ::  block-id to the first block-id in that epoch.
+        epoch-start=(h-map block-id:dt block-id:dt)
+      ::  this map contains the expected target for the child
+      ::  of a given block-id.
+        targets=(h-map block-id:dt bignum:bignum:dt)
+      ::
+      ::  Bitcoin block hash for genesis block
+      ::>)  TODO: change face to btc-hash?
+        btc-data=(unit (unit btc-hash:dt))
+        =genesis-seal:dt  ::  desired seal for genesis block
+    ==
+  ==
+
+::
++$  consensus-state  consensus-state-7
 ::
 ::  you will not have lost any chain state if you lost pending state, you'd just have to
 ::  request data again from peers and reset your mining state
@@ -277,7 +332,9 @@
 ::
 +$  admin-state-6  $+(admin-state-6 admin-state-5)
 ::
-+$  admin-state  admin-state-6
++$  admin-state-7  $+(admin-state-7 admin-state-6)
+::
++$  admin-state  admin-state-7
 ::
 +$  derived-state-0
   $+  derived-state-0
@@ -304,7 +361,9 @@
       heaviest-chain=(z-map page-number:dt block-id:dt)
   ==
 ::
-+$  derived-state  derived-state-6
++$  derived-state-7  $+(derived-state-7 derived-state-6)
+::
++$  derived-state  derived-state-7
 ::
 +$  mining-state-0
   $+  mining-state-0
@@ -336,7 +395,9 @@
       next-nonce=noun-digest:tip5:zeke  :: nonce being mined
   ==
 ::
-+$  mining-state  mining-state-6
++$  mining-state-7  $+(mining-state-7 mining-state-6)
+::
++$  mining-state  mining-state-7
 ::
 +$  init-phase  $~(%.y ?)
 ::

--- a/hoon/common/h-zoon-test.hoon
+++ b/hoon/common/h-zoon-test.hoon
@@ -1,0 +1,21 @@
+/=  *  /common/h-zoon
+/=  transact  /common/tx-engine
+|%
+++  h-test1
+  |=  [a=(h-set hashed) b=hashed]
+  ^-  ?
+  (~(has h-in a) b)
+++  h-test2
+  |=  [a=(h-set noun-digest:tip5:z)]
+  ^-  ?
+  (~(has h-in a) (atom-to-digest:tip5:z `@ux`5))
+:: This will not compile
+:: ++  h-test3
+::   |=  [a=(h-set @)]
+::   ^-  ?
+::   %.n
+++  h-test4
+  |=  [a=(h-set nname:transact)]
+  ^-  ?
+  %.n
+--

--- a/hoon/common/h-zoon-test.hoon
+++ b/hoon/common/h-zoon-test.hoon
@@ -84,4 +84,13 @@
 ::   ^-  (h-map noun-digests:z @)
 ::   =/  b=(h-map noun-digests:z @)  ~
 ::   (~(put h-by b) [(atom-to-digest:tip5:z 0x1) 0x5])
+:: ++  h-test22
+::   |=  [a=(h-set noun-digest:tip5:z)]
+::   ^-  ?
+::   (~(has z-in a) (atom-to-digest:tip5:z `@ux`5))
+::  This won't compile: z-set uses ztree, h-in expects htree
+:: ++  h-test23
+::   |=  [a=(z-set noun-digest:tip5:z)]
+::   ^-  ?
+::   (~(has h-in a) (atom-to-digest:tip5:z `@ux`5))
 --

--- a/hoon/common/h-zoon-test.hoon
+++ b/hoon/common/h-zoon-test.hoon
@@ -1,5 +1,5 @@
 /=  *  /common/h-zoon
-/=  transact  /common/tx-engine
+/=  transact  /common/tx-engine-0
 |%
 ++  h-test1
   |=  [a=(h-set hashed) b=hashed]
@@ -18,4 +18,70 @@
   |=  [a=(h-set nname:transact)]
   ^-  ?
   %.n
+++  h-test5
+  |=  [a=(h-set noun-digest:tip5:z)]
+  ^-  (z-set noun-digest:tip5:z)
+  (hz-silt a)
+++  h-test6
+  |=  [a=(z-set noun-digest:tip5:z)]
+  ^-  (h-set noun-digest:tip5:z)
+  (zh-silt a)
+:: This won't compile either
+:: ++  h-test7
+::   |=  [a=(z-set @)]
+::   ^-  (h-set @)
+::   (zh-silt a)
+++  h-test8
+  |=  [a=(h-map noun-digest:tip5:z @tas)]
+  %-  ~(rep h-by a)
+  |=  [[=noun-digest:tip5:z v=@tas] sum=_0]
+  %+  add  sum
+  `@`v
+++  h-test9
+  |=  [a=(h-map hashed @tas)]
+  (~(put h-by a) [~ 'abc'])
+:: This will not compile either
+:: ++  h-test10
+::   |=  [a=(h-map noun-digest:tip5:z @tas)]
+::   (~(put h-by a) [~ 'abc'])
+++  h-test11
+  |=  [a=(h-map nname:transact @tas)]
+  (~(put h-by a) [[(atom-to-digest:tip5:z 0x0) (atom-to-digest:tip5:z 0x0) ~] 'abc'])
+:: This will not compile either
+:: ++  h-test12
+::   |=  [a=(h-map nname:transact @tas)]
+::   (~(put h-by a) [~ 'abc'])
+++  h-test13
+  |=  [a=(h-set noun-digest:tip5:z)]
+  (~(put h-in a) (atom-to-digest:tip5:z 0x0))
+++  h-test14
+  |=  [a=(z-jug noun-digest:tip5:z noun-digest:tip5:z)]
+  (zh-jult a)
+++  h-test15
+  |=  [a=(z-mip noun-digest:tip5:z noun-digest:tip5:z ~)]
+  (zh-milt a)
+++  h-test16
+  |=  [a=~]
+  ^-  (h-map ~ @)
+  =/  b=(h-map ~ @)  ~
+  (~(put h-by b) [~ 4])
+:: ++  h-test17
+::   |=  [a=(h-map @ @)]
+::   ^-  (h-map @ @)
+::   a
+++  h-test18
+  |=  [a=(h-map noun-digest:tip5:z ~)]
+  (hz-molt a)
+++  h-test19
+  |=  [a=(h-mip noun-digest:tip5:z noun-digest:tip5:z ~)]
+  (h-test18 (~(got h-by a) (atom-to-digest:tip5:z 0x5)))
+++  h-test20
+  |=  [a=(h-mip noun-digest:tip5:z noun-digest:tip5:z ~)]
+  (hz-molt (~(got h-by a) (atom-to-digest:tip5:z 0x5)))
+:: This won't compile either
+:: ++  h-test21
+::   |=  [a=~]
+::   ^-  (h-map noun-digests:z @)
+::   =/  b=(h-map noun-digests:z @)  ~
+::   (~(put h-by b) [(atom-to-digest:tip5:z 0x1) 0x5])
 --

--- a/hoon/common/h-zoon.hoon
+++ b/hoon/common/h-zoon.hoon
@@ -3,29 +3,35 @@
 ~%  %h-zoon  ..stark-engine-jet-hook:z  ~
 |%
 ::
-+|  %no-by-in
-++  by  %do-not-use
-++  in  %do-not-use
-++  ju  %do-not-use
-++  ja  %do-not-use
-++  bi  %do-not-use
++|  %types
 +$  hashed  $^(noun-digests:z noun-digest:tip5:z)
+:: NOTE: empty-checking with ?~ does not work due to %htree. Use ?@.
+++  htree
+  |$  [item]
+  $~  ~
+  $|  $@(?(%~ %htree) [n=item l=(htree item) r=(htree item)])
+  |=  a=$@(?(%~ %htree) [n=* l=(htree) r=(htree)])
+  |-  ^-  ?
+  ?@  a  =(~ a)
+  ?&  $(a l.a)
+      $(a r.a)
+  ==
 ::
 +|  %map
 ++  h-map
   |$  [key value]                                       ::  table
-  $|  (tree (pair key value))
-  |=(a=(tree (pair hashed *)) ?:(=(~ a) & ~(apt h-by a)))
+  $|  (htree (pair key value))
+  |=(a=(htree (pair hashed *)) ?@(a =(~ a) ~(apt h-by a)))
 ::
 ++  h-by                                                  ::  h-map engine
   ~/  %h-by
-  =|  a=(tree (pair hashed *))  ::  (h-map)
+  =|  a=(htree (pair hashed *))  ::  (h-map)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       &
     ?&((b q.n.a) $(a l.a) $(a r.a))
   ::
@@ -33,7 +39,7 @@
     ~/  %any
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       |
     ?|((b q.n.a) $(a l.a) $(a r.a))
   ::
@@ -41,7 +47,7 @@
     ~/  %bif
     |*  b=*
     |-  ^+  [l=a r=a]
-    ?~  a
+    ?@  a
       [~ ~]
     ?:  =(b p.n.a)
       +.a
@@ -57,15 +63,15 @@
     ~/  %del
     |*  b=*
     |-  ^+  a
-    ?~  a
+    ?@  a
       ~
     ?.  =(b p.n.a)
       ?:  (gor-hip b p.n.a)
         a(l $(a l.a))
       a(r $(a r.a))
-    |-  ^-  [$?(~ _a)]
-    ?~  l.a  r.a
-    ?~  r.a  l.a
+    |-  ^-  [$?(?(%~ %htree) _a)]
+    ?@  l.a  r.a
+    ?@  r.a  l.a
     ?:  (mor-hip p.n.l.a p.n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
@@ -74,15 +80,15 @@
     ~/  %dif
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     =+  c=(bif p.n.b)
     ?>  ?=(^ c)
     =+  d=$(a l.c, b l.b)
     =+  e=$(a r.c, b r.b)
-    |-  ^-  [$?(~ _a)]
-    ?~  d  e
-    ?~  e  d
+    |-  ^-  [$?(?(%~ %htree) _a)]
+    ?@  d  e
+    ?@  e  d
     ?:  (mor-hip p.n.d p.n.e)
       d(r $(d r.d))
     e(l $(e l.e))
@@ -92,7 +98,7 @@
     |=  b=*
     =+  c=1
     |-  ^-  (unit @)
-    ?~  a  ~
+    ?@  a  ~
     ?:  =(b p.n.a)  [~ u=(peg c 2)]
     ?:  (gor-hip b p.n.a)
       $(a l.a, c (peg c 6))
@@ -102,12 +108,12 @@
     =<  $
     =|  [l=(unit hashed) r=(unit hashed)]
     |.  ^-  ?
-    ?~  a   &
+    ?@  a   =(~ a)
     ?&  ?~(l & &((gor-hip p.n.a u.l) !=(p.n.a u.l)))
         ?~(r & &((gor-hip u.r p.n.a) !=(u.r p.n.a)))
-        ?~  l.a   &
+        ?@  l.a   &
         &((mor-hip p.n.a p.n.l.a) !=(p.n.a p.n.l.a) $(a l.a, l `p.n.a))
-        ?~  r.a   &
+        ?@  r.a   &
         &((mor-hip p.n.a p.n.r.a) !=(p.n.a p.n.r.a) $(a r.a, r `p.n.a))
     ==
   ::
@@ -116,7 +122,7 @@
     |*  b=(list [p=* q=*])
     =>  .(b `(list _?>(?=(^ a) n.a))`b)
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
@@ -125,7 +131,7 @@
     |*  b=*
     =>  .(b `_?>(?=(^ a) p.n.a)`b)
     |-  ^-  (unit _?>(?=(^ a) q.n.a))
-    ?~  a
+    ?@  a
       ~
     ?:  =(b p.n.a)
       (some q.n.a)
@@ -152,9 +158,9 @@
     ~/  %int
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       ~
-    ?~  a
+    ?@  a
       ~
     ?:  (mor-hip p.n.a p.n.b)
       ?:  =(p.n.b p.n.a)
@@ -173,7 +179,7 @@
     |*  [key=_?>(?=(^ a) p.n.a) fun=$-(_?>(?=(^ a) q.n.a) _?>(?=(^ a) q.n.a))]
     ^+  a
     ::
-    ?~  a  !!
+    ?@  a  !!
     ::
     ?:  =(key p.n.a)
       a(q.n (fun q.n.a))
@@ -194,7 +200,7 @@
     ~/  %put
     |*  [b=* c=*]
     |-  ^+  a
-    ?~  a
+    ?@  a
       [[b c] ~ ~]
     ?:  =(b p.n.a)
       ?:  =(c q.n.a)
@@ -216,14 +222,14 @@
     ~/  %rep
     |*  b=_=>(~ |=([* *] +<+))
     |-
-    ?~  a  +<+.b
+    ?@  a  +<+.b
     $(a r.a, +<+.b $(a l.a, +<+.b (b n.a +<+.b)))
   ::
   ++  rib                                               ::  transform + product
     ~/  %rib
     |*  [b=* c=gate]
     |-  ^+  [b a]
-    ?~  a  [b ~]
+    ?@  a  [b ~]
     =+  d=(c n.a b)
     =.  n.a  +.d
     =+  e=$(a l.a, b -.d)
@@ -234,14 +240,14 @@
     ~/  %run
     |*  b=gate
     |-
-    ?~  a  a
+    ?@  a  a
     [n=[p=p.n.a q=(b q.n.a)] l=$(a l.a) r=$(a r.a)]
   ::
   ++  tap                                               ::  listify pairs
     =<  $
     =+  b=`(list _?>(?=(^ a) n.a))`~
     |.  ^+  b
-    ?~  a
+    ?@  a
       b
     $(a r.a, b [n.a $(a l.a)])
   ::
@@ -249,9 +255,9 @@
     ~/  %uni
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
-    ?~  a
+    ?@  a
       b
     ?:  =(p.n.b p.n.a)
       b(l $(a l.a, b l.b), r $(a r.a, b r.b))
@@ -268,9 +274,9 @@
     |*  b=_a
     |*  meg=$-([* * *] *)
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
-    ?~  a
+    ?@  a
       b
     ?:  =(p.n.b p.n.a)
       :+  [p.n.a `_?>(?=(^ a) q.n.a)`(meg p.n.a q.n.a q.n.b)]
@@ -288,40 +294,40 @@
     ~/  %urn
     |*  b=$-([* *] *)
     |-
-    ?~  a  ~
+    ?@  a  ~
     a(n n.a(q (b p.n.a q.n.a)), l $(a l.a), r $(a r.a))
   ::
   ++  wyt                                               ::  depth of h-map
     =<  $
     |.  ^-  @
-    ?~(a 0 +((add $(a l.a) $(a r.a))))
+    ?@(a 0 +((add $(a l.a) $(a r.a))))
   ::
   ++  key                                               ::  h-set of keys
     |-  ^-  (h-set _?>(?=(^ a) p.n.a))
-    ?~  a  ~
+    ?@  a  ~
     [p.n.a $(a l.a) $(a r.a)]
   ::
   ++  val                                               ::  list of vals
     =+  b=`(list _?>(?=(^ a) q.n.a))`~
     |-  ^+  b
-    ?~  a   b
+    ?@  a   b
     $(a r.a, b [q.n.a $(a l.a)])
   --
 +|  %set
 ++  h-set
   |$  [item]                                            ::  h-set
-  $|  (tree item)
-  |=(a=(tree item) ?:(=(~ a) & ~(apt h-in a)))
+  $|  (htree item)
+  |=(a=(htree item) ?@(a =(~ a) ~(apt h-in a)))
 ::
 ++  h-in                                                  ::  h-set engine
   ~/  %h-in
-  =|  a=(tree hashed)  :: (h-set)
+  =|  a=(htree hashed)  :: (h-set)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       &
     ?&((b n.a) $(a l.a) $(a r.a))
   ::
@@ -329,7 +335,7 @@
     ~/  %any
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       |
     ?|((b n.a) $(a l.a) $(a r.a))
   ::
@@ -337,11 +343,11 @@
     =<  $
     =|  [l=(unit hashed) r=(unit hashed)]
     |.  ^-  ?
-    ?~  a   &
+    ?@  a   =(~ a)
     ?&  ?~(l & &((gor-hip n.a u.l) !=(n.a u.l)))
         ?~(r & &((gor-hip u.r n.a) !=(u.r n.a)))
-        ?~(l.a & ?&((mor-hip n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
-        ?~(r.a & ?&((mor-hip n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
+        ?@(l.a & ?&((mor-hip n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
+        ?@(r.a & ?&((mor-hip n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
     ==
   ::
   ++  bif                                               ::  splits a by b
@@ -350,7 +356,7 @@
     ^+  [l=a r=a]
     =<  +
     |-  ^+  a
-    ?~  a
+    ?@  a
       [b ~ ~]
     ?:  =(b n.a)
       a
@@ -366,15 +372,15 @@
     ~/  %del
     |*  b=*
     |-  ^+  a
-    ?~  a
+    ?@  a
       ~
     ?.  =(b n.a)
       ?:  (gor-hip b n.a)
         a(l $(a l.a))
       a(r $(a r.a))
-    |-  ^-  [$?(~ _a)]
-    ?~  l.a  r.a
-    ?~  r.a  l.a
+    |-  ^-  [$?(?(%~ %htree) _a)]
+    ?@  l.a  r.a
+    ?@  r.a  l.a
     ?:  (mor-hip n.l.a n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
@@ -383,15 +389,15 @@
     ~/  %dif
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     =+  c=(bif n.b)
     ?>  ?=(^ c)
     =+  d=$(a l.c, b l.b)
     =+  e=$(a r.c, b r.b)
-    |-  ^-  [$?(~ _a)]
-    ?~  d  e
-    ?~  e  d
+    |-  ^-  [$?(?(%~ %htree) _a)]
+    ?@  d  e
+    ?@  e  d
     ?:  (mor-hip n.d n.e)
       d(r $(d r.d))
     e(l $(e l.e))
@@ -401,7 +407,7 @@
     |=  b=*
     =+  c=1
     |-  ^-  (unit @)
-    ?~  a  ~
+    ?@  a  ~
     ?:  =(b n.a)  [~ u=(peg c 2)]
     ?:  (gor-hip b n.a)
       $(a l.a, c (peg c 6))
@@ -411,7 +417,7 @@
     ~/  %gas
     |=  b=(list _?>(?=(^ a) n.a))
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     $(b t.b, a (put i.b))
   ::  +has: does :b exist h-in :a?
@@ -435,7 +441,7 @@
     |=  b=(unit _?>(?=(^ a) n.a))
     =>  .(b ?>(?=(^ b) u.b))
     |-  ^-  ?
-    ?~  a
+    ?@  a
       |
     ?:  =(b n.a)
       &
@@ -447,9 +453,9 @@
     ~/  %int
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       ~
-    ?~  a
+    ?@  a
       ~
     ?.  (mor-hip n.a n.b)
       $(a b, b a)
@@ -463,7 +469,7 @@
     ~/  %put
     |*  b=hashed
     |-  ^+  a
-    ?~  a
+    ?@  a
       [b ~ ~]
     ?:  =(b n.a)
       a
@@ -483,14 +489,14 @@
     ~/  %rep
     |*  b=_=>(~ |=([* *] +<+))
     |-
-    ?~  a  +<+.b
+    ?@  a  +<+.b
     $(a r.a, +<+.b $(a l.a, +<+.b (b n.a +<+.b)))
   ::
   ++  run                                               ::  apply gate to values
     ~/  %run
     |*  b=gate
     =+  c=`(h-set _?>(?=(^ a) (b n.a)))`~
-    |-  ?~  a  c
+    |-  ?@  a  c
     =.  c  (~(put h-in c) (b n.a))
     =.  c  $(a l.a, c c)
     $(a r.a, c c)
@@ -499,7 +505,7 @@
     =<  $
     =+  b=`(list _?>(?=(^ a) n.a))`~
     |.  ^+  b
-    ?~  a
+    ?@  a
       b
     $(a r.a, b [n.a $(a l.a)])
   ::
@@ -508,9 +514,9 @@
     |*  b=_a
     ?:  =(a b)  a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
-    ?~  a
+    ?@  a
       b
     ?:  =(n.b n.a)
       b(l $(a l.a, b l.b), r $(a r.a, b r.b))
@@ -525,7 +531,7 @@
   ++  wyt                                               ::  size of h-set
     =<  $
     |.  ^-  @
-    ?~(a 0 +((add $(a l.a) $(a r.a))))
+    ?@(a 0 +((add $(a l.a) $(a r.a))))
   --
 +|  %mip
 ::
@@ -540,7 +546,7 @@
     |*  [b=* c=*]
     =+  d=(~(gut h-by a) b ~)
     =+  e=(~(del h-by d) c)
-    ?~  e
+    ?@  e
       (~(del h-by a) b)
     (~(put h-by a) b e)
   ::
@@ -578,7 +584,7 @@
     =<  $
     =+  b=`_?>(?=(^ a) *(list [x=_p.n.a _?>(?=(^ q.n.a) [y=p v=q]:n.q.n.a)]))`~
     |.  ^+  b
-    ?~  a
+    ?@  a
       b
     $(a r.a, b (welp (turn ~(tap h-by q.n.a) (lead p.n.a)) $(a l.a)))
   --
@@ -590,14 +596,14 @@
   (h-map key (h-set value))
 ::
 ++  h-ju                                                ::  h-jug engine
-  =|  a=(tree (pair hashed (tree hashed *)))            ::  (h-jug)
+  =|  a=(htree (pair hashed (htree hashed *)))            ::  (h-jug)
   |@
   ++  del                                               ::  del key-set pair
     |*  [b=* c=*]
     ^+  a
     =+  d=(get b)
     =+  e=(~(del h-in d) c)
-    ?~  e
+    ?@  e
       (~(del h-by a) b)
     (~(put h-by a) b e)
   ::
@@ -605,7 +611,7 @@
     |*  b=(list [p=* q=*])
     =>  .(b `(list _?>(?=([[* ^] ^] a) [p=p q=n.q]:n.a))`b)
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
@@ -684,12 +690,12 @@
 +|   %h-container-from-container
   ++  h-silt                                              :: h-set from list
     |*  a=(list)
-    =+  b=*(tree _?>(?=(^ a) i.a))
+    =+  b=*(htree _?>(?=(^ a) i.a))
     (~(gas h-in b) a)
   ::
   ++  h-molt                                              :: h-map from pair
       |*  a=(list (pair))
-      (~(gas h-by `(tree [p=_p.i.-.a q=_q.i.-.a])`~) a)
+      (~(gas h-by `(htree [p=_p.i.-.a q=_q.i.-.a])`~) a)
   ::
   ++  h-malt                                              ::  h-map from list
   |*  a=(list)

--- a/hoon/common/h-zoon.hoon
+++ b/hoon/common/h-zoon.hoon
@@ -1,5 +1,5 @@
 ::  /lib/zoon: vendored types from hoon.hoon
-/=  z  /common/zeke
+/=  *  /common/zoon
 ~%  %h-zoon  ..stark-engine-jet-hook:z  ~
 |%
 ::
@@ -17,7 +17,7 @@
 +|  %map
 ++  h-map
   |$  [key value]                                       ::  table
-  $|  (tree (pair hashed value))
+  $|  (tree (pair key value))
   |=(a=(tree (pair hashed *)) ?:(=(~ a) & ~(apt h-by a)))
 ::
 ++  h-by                                                  ::  h-map engine
@@ -464,7 +464,7 @@
   ::
   ++  put                                               ::  puts b h-in a, sorted
     ~/  %put
-    |*  b=*
+    |*  b=hashed
     |-  ^+  a
     ?~  a
       [b ~ ~]
@@ -537,7 +537,7 @@
   (h-map kex (h-map key value))
 ::
 ++  h-bi                                                  ::  mip engine
-  =|  a=(h-map * (h-map))
+  =|  a=(h-map hashed (h-map hashed *))
   |@
   ++  del
     |*  [b=* c=*]
@@ -593,7 +593,7 @@
   (h-map key (h-set value))
 ::
 ++  h-ju                                                ::  h-jug engine
-  =|  a=(tree (pair * (tree)))                          ::  (h-jug)
+  =|  a=(tree (pair hashed (tree hashed *)))            ::  (h-jug)
   |@
   ++  del                                               ::  del key-set pair
     |*  [b=* c=*]
@@ -699,4 +699,36 @@
   ++  h-malt                                              ::  h-map from list
   |*  a=(list)
   (h-molt `(list [p=_-<.a q=_->.a])`a)
+  ::
+  ++  zh-molt
+  |*  a=(z-map hashed *)
+  (h-molt ~(tap z-by a))
+  ::
+  ++  zh-jult
+  |*  a=(z-jug hashed hashed)
+  (zh-molt (~(run z-by a) zh-silt))
+  ::
+  ++  zh-milt
+  |*  a=(z-mip hashed hashed hashed)
+  (zh-molt (~(run z-by a) zh-molt))
+  ::
+  ++  hz-molt
+  |*  a=(h-map hashed *)
+  (z-molt ~(tap h-by a))
+  ::
+  ++  zh-silt
+  |*  a=(z-set hashed)
+  (h-silt ~(tap z-in a))
+  ::
+  ++  hz-silt
+  |*  a=(h-set hashed)
+  (z-silt ~(tap h-in a))
+  ::
+  ++  hz-jult
+  |*  a=(h-jug hashed hashed)
+  (hz-molt (~(run h-by a) hz-silt))
+  ::
+  ++  hz-milt
+  |*  a=(h-mip hashed hashed hashed)
+  (hz-molt (~(run h-by a) hz-molt))
 --

--- a/hoon/common/h-zoon.hoon
+++ b/hoon/common/h-zoon.hoon
@@ -1,6 +1,6 @@
 ::  /lib/zoon: vendored types from hoon.hoon
-/=  *  /common/h-zoon
-~%  %zoon  ..stark-engine-jet-hook:z  ~
+/=  z  /common/zeke
+~%  %h-zoon  ..stark-engine-jet-hook:z  ~
 |%
 ::
 +|  %no-by-in
@@ -9,16 +9,20 @@
 ++  ju  %do-not-use
 ++  ja  %do-not-use
 ++  bi  %do-not-use
++$  hashed
+  $?  noun-digest:tip5:z
+      noun-digests:z
+  ==
 ::
 +|  %map
-++  z-map
+++  h-map
   |$  [key value]                                       ::  table
-  $|  (tree (pair key value))
-  |=(a=(tree (pair)) ?:(=(~ a) & ~(apt z-by a)))
+  $|  (tree (pair hashed value))
+  |=(a=(tree (pair hashed *)) ?:(=(~ a) & ~(apt h-by a)))
 ::
-++  z-by                                                  ::  z-map engine
-  ~/  %z-by
-  =|  a=(tree (pair))  ::  (z-map)
+++  h-by                                                  ::  h-map engine
+  ~/  %h-by
+  =|  a=(tree (pair hashed *))  ::  (h-map)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
@@ -36,7 +40,7 @@
       |
     ?|((b q.n.a) $(a l.a) $(a r.a))
   ::
-  ++  bif                                               ::  splits a z-by b
+  ++  bif                                               ::  splits a h-by b
     ~/  %bif
     |*  b=*
     |-  ^+  [l=a r=a]
@@ -44,7 +48,7 @@
       [~ ~]
     ?:  =(b p.n.a)
       +.a
-    ?:  (gor-tip b p.n.a)
+    ?:  (gor-hip b p.n.a)
       =+  d=$(a l.a)
       ?>  ?=(^ d)
       [l.d a(l r.d)]
@@ -59,13 +63,13 @@
     ?~  a
       ~
     ?.  =(b p.n.a)
-      ?:  (gor-tip b p.n.a)
+      ?:  (gor-hip b p.n.a)
         a(l $(a l.a))
       a(r $(a r.a))
     |-  ^-  [$?(~ _a)]
     ?~  l.a  r.a
     ?~  r.a  l.a
-    ?:  (mor-tip p.n.l.a p.n.r.a)
+    ?:  (mor-hip p.n.l.a p.n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
   ::
@@ -82,7 +86,7 @@
     |-  ^-  [$?(~ _a)]
     ?~  d  e
     ?~  e  d
-    ?:  (mor-tip p.n.d p.n.e)
+    ?:  (mor-hip p.n.d p.n.e)
       d(r $(d r.d))
     e(l $(e l.e))
   ::
@@ -93,21 +97,21 @@
     |-  ^-  (unit @)
     ?~  a  ~
     ?:  =(b p.n.a)  [~ u=(peg c 2)]
-    ?:  (gor-tip b p.n.a)
+    ?:  (gor-hip b p.n.a)
       $(a l.a, c (peg c 6))
     $(a r.a, c (peg c 7))
   ::
   ++  apt                                               ::  check correctness
     =<  $
-    =|  [l=(unit) r=(unit)]
+    =|  [l=(unit hashed) r=(unit hashed)]
     |.  ^-  ?
     ?~  a   &
-    ?&  ?~(l & &((gor-tip p.n.a u.l) !=(p.n.a u.l)))
-        ?~(r & &((gor-tip u.r p.n.a) !=(u.r p.n.a)))
+    ?&  ?~(l & &((gor-hip p.n.a u.l) !=(p.n.a u.l)))
+        ?~(r & &((gor-hip u.r p.n.a) !=(u.r p.n.a)))
         ?~  l.a   &
-        &((mor-tip p.n.a p.n.l.a) !=(p.n.a p.n.l.a) $(a l.a, l `p.n.a))
+        &((mor-hip p.n.a p.n.l.a) !=(p.n.a p.n.l.a) $(a l.a, l `p.n.a))
         ?~  r.a   &
-        &((mor-tip p.n.a p.n.r.a) !=(p.n.a p.n.r.a) $(a r.a, r `p.n.a))
+        &((mor-hip p.n.a p.n.r.a) !=(p.n.a p.n.r.a) $(a r.a, r `p.n.a))
     ==
   ::
   ++  gas                                               ::  concatenate
@@ -119,7 +123,7 @@
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
-  ++  get                                               ::  grab value z-by key
+  ++  get                                               ::  grab value h-by key
     ~/  %get
     |*  b=*
     =>  .(b `_?>(?=(^ a) p.n.a)`b)
@@ -128,16 +132,16 @@
       ~
     ?:  =(b p.n.a)
       (some q.n.a)
-    ?:  (gor-tip b p.n.a)
+    ?:  (gor-hip b p.n.a)
       $(a l.a)
     $(a r.a)
   ::
-  ++  got                                               ::  need value z-by key
+  ++  got                                               ::  need value h-by key
     ~/  %got
     |*  b=*
     (need (get b))
   ::
-  ++  gut                                               ::  fall value z-by key
+  ++  gut                                               ::  fall value h-by key
     ~/  %gut
     |*  [b=* c=*]
     (fall (get b) c)
@@ -155,15 +159,15 @@
       ~
     ?~  a
       ~
-    ?:  (mor-tip p.n.a p.n.b)
+    ?:  (mor-hip p.n.a p.n.b)
       ?:  =(p.n.b p.n.a)
         b(l $(a l.a, b l.b), r $(a r.a, b r.b))
-      ?:  (gor-tip p.n.b p.n.a)
+      ?:  (gor-hip p.n.b p.n.a)
         %-  uni(a $(a l.a, r.b ~))  $(b r.b)
       %-  uni(a $(a r.a, l.b ~))  $(b l.b)
     ?:  =(p.n.a p.n.b)
       b(l $(b l.b, a l.a), r $(b r.b, a r.a))
-    ?:  (gor-tip p.n.a p.n.b)
+    ?:  (gor-hip p.n.a p.n.b)
       %-  uni(a $(b l.b, r.a ~))  $(a r.a)
     %-  uni(a $(b r.b, l.a ~))  $(a l.a)
   ::
@@ -177,7 +181,7 @@
     ?:  =(key p.n.a)
       a(q.n (fun q.n.a))
     ::
-    ?:  (gor-tip key p.n.a)
+    ?:  (gor-hip key p.n.a)
       a(l $(a l.a))
     ::
     a(r $(a r.a))
@@ -199,15 +203,15 @@
       ?:  =(c q.n.a)
         a
       a(n [b c])
-    ?:  (gor-tip b p.n.a)
+    ?:  (gor-hip b p.n.a)
       =+  d=$(a l.a)
       ?>  ?=(^ d)
-      ?:  (mor-tip p.n.a p.n.d)
+      ?:  (mor-hip p.n.a p.n.d)
         a(l d)
       d(r a(l r.d))
     =+  d=$(a r.a)
     ?>  ?=(^ d)
-    ?:  (mor-tip p.n.a p.n.d)
+    ?:  (mor-hip p.n.a p.n.d)
       a(r d)
     d(l a(r l.d))
   ::
@@ -254,11 +258,11 @@
       b
     ?:  =(p.n.b p.n.a)
       b(l $(a l.a, b l.b), r $(a r.a, b r.b))
-    ?:  (mor-tip p.n.a p.n.b)
-      ?:  (gor-tip p.n.b p.n.a)
+    ?:  (mor-hip p.n.a p.n.b)
+      ?:  (gor-hip p.n.b p.n.a)
         $(l.a $(a l.a, r.b ~), b r.b)
       $(r.a $(a r.a, l.b ~), b l.b)
-    ?:  (gor-tip p.n.a p.n.b)
+    ?:  (gor-hip p.n.a p.n.b)
       $(l.b $(b l.b, r.a ~), a r.a)
     $(r.b $(b r.b, l.a ~), a l.a)
   ::
@@ -275,11 +279,11 @@
       :+  [p.n.a `_?>(?=(^ a) q.n.a)`(meg p.n.a q.n.a q.n.b)]
         $(b l.b, a l.a)
       $(b r.b, a r.a)
-    ?:  (mor-tip p.n.a p.n.b)
-      ?:  (gor-tip p.n.b p.n.a)
+    ?:  (mor-hip p.n.a p.n.b)
+      ?:  (gor-hip p.n.b p.n.a)
         $(l.a $(a l.a, r.b ~), b r.b)
       $(r.a $(a r.a, l.b ~), b l.b)
-    ?:  (gor-tip p.n.a p.n.b)
+    ?:  (gor-hip p.n.a p.n.b)
       $(l.b $(b l.b, r.a ~), a r.a)
     $(r.b $(b r.b, l.a ~), a l.a)
   ::
@@ -290,13 +294,13 @@
     ?~  a  ~
     a(n n.a(q (b p.n.a q.n.a)), l $(a l.a), r $(a r.a))
   ::
-  ++  wyt                                               ::  depth of z-map
+  ++  wyt                                               ::  depth of h-map
     =<  $
     |.  ^-  @
     ?~(a 0 +((add $(a l.a) $(a r.a))))
   ::
-  ++  key                                               ::  z-set of keys
-    |-  ^-  (z-set _?>(?=(^ a) p.n.a))
+  ++  key                                               ::  h-set of keys
+    |-  ^-  (h-set _?>(?=(^ a) p.n.a))
     ?~  a  ~
     [p.n.a $(a l.a) $(a r.a)]
   ::
@@ -307,14 +311,14 @@
     $(a r.a, b [q.n.a $(a l.a)])
   --
 +|  %set
-++  z-set
-  |$  [item]                                            ::  z-set
+++  h-set
+  |$  [item]                                            ::  h-set
   $|  (tree item)
-  |=(a=(tree) ?:(=(~ a) & ~(apt z-in a)))
+  |=(a=(tree item) ?:(=(~ a) & ~(apt h-in a)))
 ::
-++  z-in                                                  ::  z-set engine
-  ~/  %z-in
-  =|  a=(tree)  :: (z-set)
+++  h-in                                                  ::  h-set engine
+  ~/  %h-in
+  =|  a=(tree hashed)  :: (h-set)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
@@ -334,13 +338,13 @@
   ::
   ++  apt                                               ::  check correctness
     =<  $
-    =|  [l=(unit) r=(unit)]
+    =|  [l=(unit hashed) r=(unit hashed)]
     |.  ^-  ?
     ?~  a   &
-    ?&  ?~(l & &((gor-tip n.a u.l) !=(n.a u.l)))
-        ?~(r & &((gor-tip u.r n.a) !=(u.r n.a)))
-        ?~(l.a & ?&((mor-tip n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
-        ?~(r.a & ?&((mor-tip n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
+    ?&  ?~(l & &((gor-hip n.a u.l) !=(n.a u.l)))
+        ?~(r & &((gor-hip u.r n.a) !=(u.r n.a)))
+        ?~(l.a & ?&((mor-hip n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
+        ?~(r.a & ?&((mor-hip n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
     ==
   ::
   ++  bif                                               ::  splits a by b
@@ -353,7 +357,7 @@
       [b ~ ~]
     ?:  =(b n.a)
       a
-    ?:  (gor-tip b n.a)
+    ?:  (gor-hip b n.a)
       =+  c=$(a l.a)
       ?>  ?=(^ c)
       c(r a(l r.c))
@@ -368,13 +372,13 @@
     ?~  a
       ~
     ?.  =(b n.a)
-      ?:  (gor-tip b n.a)
+      ?:  (gor-hip b n.a)
         a(l $(a l.a))
       a(r $(a r.a))
     |-  ^-  [$?(~ _a)]
     ?~  l.a  r.a
     ?~  r.a  l.a
-    ?:  (mor-tip n.l.a n.r.a)
+    ?:  (mor-hip n.l.a n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
   ::
@@ -391,18 +395,18 @@
     |-  ^-  [$?(~ _a)]
     ?~  d  e
     ?~  e  d
-    ?:  (mor-tip n.d n.e)
+    ?:  (mor-hip n.d n.e)
       d(r $(d r.d))
     e(l $(e l.e))
   ::
-  ++  dig                                               ::  axis of a z-in b
+  ++  dig                                               ::  axis of a h-in b
     ~/  %dig
     |=  b=*
     =+  c=1
     |-  ^-  (unit @)
     ?~  a  ~
     ?:  =(b n.a)  [~ u=(peg c 2)]
-    ?:  (gor-tip b n.a)
+    ?:  (gor-hip b n.a)
       $(a l.a, c (peg c 6))
     $(a r.a, c (peg c 7))
   ::
@@ -413,19 +417,19 @@
     ?~  b
       a
     $(b t.b, a (put i.b))
-  ::  +has: does :b exist z-in :a?
+  ::  +has: does :b exist h-in :a?
   ::
   ++  has
     ~/  %has
     |*  b=*
     ^-  ?
-    ::    wrap extracted item type z-in a unit because bunting fails
+    ::    wrap extracted item type h-in a unit because bunting fails
     ::
     ::  If we used the real item type of _?^(a n.a !!) as the sample type,
     ::  then hoon would bunt it to create the default sample for the gate.
     ::
     ::  However, bunting that expression fails if :a is ~. If we wrap it
-    ::  z-in a unit, the bunted unit doesn't include the bunted item type.
+    ::  h-in a unit, the bunted unit doesn't include the bunted item type.
     ::
     ::  This way we can ensure type safety of :b without needing to perform
     ::  this failing bunt. It's a hack.
@@ -438,7 +442,7 @@
       |
     ?:  =(b n.a)
       &
-    ?:  (gor-tip b n.a)
+    ?:  (gor-hip b n.a)
       $(a l.a)
     $(a r.a)
   ::
@@ -450,15 +454,15 @@
       ~
     ?~  a
       ~
-    ?.  (mor-tip n.a n.b)
+    ?.  (mor-hip n.a n.b)
       $(a b, b a)
     ?:  =(n.b n.a)
       a(l $(a l.a, b l.b), r $(a r.a, b r.b))
-    ?:  (gor-tip n.b n.a)
+    ?:  (gor-hip n.b n.a)
       %-  uni(a $(a l.a, r.b ~))  $(b r.b)
     %-  uni(a $(a r.a, l.b ~))  $(b l.b)
   ::
-  ++  put                                               ::  puts b z-in a, sorted
+  ++  put                                               ::  puts b h-in a, sorted
     ~/  %put
     |*  b=*
     |-  ^+  a
@@ -466,15 +470,15 @@
       [b ~ ~]
     ?:  =(b n.a)
       a
-    ?:  (gor-tip b n.a)
+    ?:  (gor-hip b n.a)
       =+  c=$(a l.a)
       ?>  ?=(^ c)
-      ?:  (mor-tip n.a n.c)
+      ?:  (mor-hip n.a n.c)
         a(l c)
       c(r a(l r.c))
     =+  c=$(a r.a)
     ?>  ?=(^ c)
-    ?:  (mor-tip n.a n.c)
+    ?:  (mor-hip n.a n.c)
       a(r c)
     c(l a(r l.c))
   ::
@@ -488,9 +492,9 @@
   ++  run                                               ::  apply gate to values
     ~/  %run
     |*  b=gate
-    =+  c=`(z-set _?>(?=(^ a) (b n.a)))`~
+    =+  c=`(h-set _?>(?=(^ a) (b n.a)))`~
     |-  ?~  a  c
-    =.  c  (~(put z-in c) (b n.a))
+    =.  c  (~(put h-in c) (b n.a))
     =.  c  $(a l.a, c c)
     $(a r.a, c c)
   ::
@@ -513,41 +517,41 @@
       b
     ?:  =(n.b n.a)
       b(l $(a l.a, b l.b), r $(a r.a, b r.b))
-    ?:  (mor-tip n.a n.b)
-      ?:  (gor-tip n.b n.a)
+    ?:  (mor-hip n.a n.b)
+      ?:  (gor-hip n.b n.a)
         $(l.a $(a l.a, r.b ~), b r.b)
       $(r.a $(a r.a, l.b ~), b l.b)
-    ?:  (gor-tip n.a n.b)
+    ?:  (gor-hip n.a n.b)
       $(l.b $(b l.b, r.a ~), a r.a)
     $(r.b $(b r.b, l.a ~), a l.a)
   ::
-  ++  wyt                                               ::  size of z-set
+  ++  wyt                                               ::  size of h-set
     =<  $
     |.  ^-  @
     ?~(a 0 +((add $(a l.a) $(a r.a))))
   --
 +|  %mip
 ::
-++  z-mip                                                 ::  map of maps
+++  h-mip                                                 ::  map of maps
   |$  [kex key value]
-  (z-map kex (z-map key value))
+  (h-map kex (h-map key value))
 ::
-++  z-bi                                                  ::  mip engine
-  =|  a=(z-map * (z-map))
+++  h-bi                                                  ::  mip engine
+  =|  a=(h-map * (h-map))
   |@
   ++  del
     |*  [b=* c=*]
-    =+  d=(~(gut z-by a) b ~)
-    =+  e=(~(del z-by d) c)
+    =+  d=(~(gut h-by a) b ~)
+    =+  e=(~(del h-by d) c)
     ?~  e
-      (~(del z-by a) b)
-    (~(put z-by a) b e)
+      (~(del h-by a) b)
+    (~(put h-by a) b e)
   ::
   ++  get
     |*  [b=* c=*]
     =>  .(b `_?>(?=(^ a) p.n.a)`b, c `_?>(?=(^ a) ?>(?=(^ q.n.a) p.n.q.n.a))`c)
     ^-  (unit _?>(?=(^ a) ?>(?=(^ q.n.a) q.n.q.n.a)))
-    (~(get z-by (~(gut z-by a) b ~)) c)
+    (~(get h-by (~(gut h-by a) b ~)) c)
   ::
   ++  got
     |*  [b=* c=*]
@@ -555,7 +559,7 @@
   ::
   ++  gut
     |*  [b=* c=* d=*]
-    (~(gut z-by (~(gut z-by a) b ~)) c d)
+    (~(gut h-by (~(gut h-by a) b ~)) c d)
   ::
   ++  has
     |*  [b=* c=*]
@@ -563,14 +567,14 @@
   ::
   ++  key
     |*  b=*
-    ~(key z-by (~(gut z-by a) b ~))
+    ~(key h-by (~(gut h-by a) b ~))
   ::
   ++  put
     |*  [b=* c=* d=*]
-    %+  ~(put z-by a)  b
+    %+  ~(put h-by a)  b
     %.  [c d]
-    %~  put  z-by
-    (~(gut z-by a) b ~)
+    %~  put  h-by
+    (~(gut h-by a) b ~)
   ::
   ++  tap
     ::NOTE  naive turn-based implementation find-errors ):
@@ -579,26 +583,26 @@
     |.  ^+  b
     ?~  a
       b
-    $(a r.a, b (welp (turn ~(tap z-by q.n.a) (lead p.n.a)) $(a l.a)))
+    $(a r.a, b (welp (turn ~(tap h-by q.n.a) (lead p.n.a)) $(a l.a)))
   --
 ::
 +|  %jug
 ::
-++  z-jug
+++  h-jug
   |$  [key value]
-  (z-map key (z-set value))
+  (h-map key (h-set value))
 ::
-++  z-ju                                                ::  z-jug engine
-  =|  a=(tree (pair * (tree)))                          ::  (z-jug)
+++  h-ju                                                ::  h-jug engine
+  =|  a=(tree (pair * (tree)))                          ::  (h-jug)
   |@
   ++  del                                               ::  del key-set pair
     |*  [b=* c=*]
     ^+  a
     =+  d=(get b)
-    =+  e=(~(del z-in d) c)
+    =+  e=(~(del h-in d) c)
     ?~  e
-      (~(del z-by a) b)
-    (~(put z-by a) b e)
+      (~(del h-by a) b)
+    (~(put h-by a) b e)
   ::
   ++  gas                                               ::  concatenate
     |*  b=(list [p=* q=*])
@@ -608,93 +612,91 @@
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
-  ++  get                                               ::  gets z-set by key
+  ++  get                                               ::  gets h-set by key
     |*  b=*
-    =+  c=(~(get z-by a) b)
+    =+  c=(~(get h-by a) b)
     ?~(c ~ u.c)
   ::
   ++  has                                               ::  existence check
     |*  [b=* c=*]
     ^-  ?
-    (~(has z-in (get b)) c)
+    (~(has h-in (get b)) c)
   ::
-  ++  put                                               ::  add key-z-set pair
+  ++  put                                               ::  add key-h-set pair
     |*  [b=* c=*]
     ^+  a
     =+  d=(get b)
-    (~(put z-by a) b (~(put z-in d) c))
+    (~(put h-by a) b (~(put h-in d) c))
   --
 ::
 +|  %ordering
-::  +dor-tip: depth order.
+::  +gor-hip: pre-hashed tip order.
 ::
-::    Orders z-in ascending tree depth.
+::    Orders h-in ascending +tip hash order, collisions assumed not exist.
 ::
-++  dor-tip
-  ~/  %dor-tip
-  |=  [a=* b=*]
+++  gor-hip
+  ~/  %gor-hip
+  |=  [a=hashed b=hashed]
   ^-  ?
-  ?:  =(a b)  &
-  ?.  ?=(@ a)
-    ?:  ?=(@ b)  |
-    ?:  =(-.a -.b)
-      $(a +.a, b +.b)
-    $(a -.a, b -.b)
-  ?.  ?=(@ b)  &
-  (lth a b)
-::  +gor-tip: tip order.
+  (gor-digests (hashed-to-digests a) (hashed-to-digests b))
+::  +mor-hip: mor pre-hashed tip order.
 ::
-::    Orders z-in ascending +tip hash order, collisions fall back to +dor.
+::    Orders h-in ascending double +tip hash order, collisions assumed not exist.
 ::
-++  gor-tip
-  ~/  %gor-tip
-  |=  [a=* b=*]
+++  mor-hip
+  ~/  %mor-hip
+  |=  [a=hashed b=hashed]
   ^-  ?
-  =+  [c=(tip a) d=(tip b)]
-  ?:  =(c d)
-    (dor-tip a b)
-  (lth-tip c d)
-::  +mor-tip: mor tip order.
+  (gor-digests (hashed-to-digests a) (hashed-to-digests b))
 ::
-::    Orders z-in ascending double +tip hash order, collisions fall back to +dor.
+++  hashed-to-digests
+  |=  a=hashed
+  ^-  noun-digests:z
+  ?:  ?=(@ a)
+    ~
+  ?:  ?=(@ -.a)
+    [a ~]
+  a
 ::
-++  mor-tip
-  ~/  %mor-tip
-  |=  [a=* b=*]
+++  gor-digests
+  |=  [a=noun-digests:z b=noun-digests:z]
   ^-  ?
-  =+  [c=(double-tip a) d=(double-tip b)]
-  ?:  =(c d)
-    (dor-tip a b)
-  (lth-tip c d)
+  ?~  a  %.n
+  ?~  b  %.y
+  =+  c=(digest-to-atom:tip5:z i.a)
+  =+  d=(digest-to-atom:tip5:z i.b)
+  ?:  (gth c d)  %.y
+  ?:  (lth c d)  %.n
+  $(a t.a, b t.b)
 ::
-++  tip
-  |=  a=*
+++  rev-tip
+  |=  a=noun-digest:tip5:z
   ^-  noun-digest:tip5:z
-  (hash-noun-varlen:tip5:z a)
+  =+  [b c d e f]=a
+  [f e d c b]
 ::
-++  double-tip
-  |=  a=*
-  ^-  noun-digest:tip5:z
-  =/  one  (tip a)
-  (hash-ten-cell:tip5:z one one)
+++  mor-digests
+  |=  [a=noun-digests:z b=noun-digests:z]
+  ^-  ?
+  ?~  a  %.n
+  ?~  b  %.y
+  =+  c=(digest-to-atom:tip5:z (rev-tip i.a))
+  =+  d=(digest-to-atom:tip5:z (rev-tip i.b))
+  ?:  (gth c d)  %.y
+  ?:  (lth c d)  %.n
+  $(a t.a, b t.b)
 ::
-++  lth-tip
-  |=  [a=noun-digest:tip5:z b=noun-digest:tip5:z]
-  %+  lth
-    (digest-to-atom:tip5:z a)
-  (digest-to-atom:tip5:z b)
-::
-+|   %z-container-from-container
-  ++  z-silt                                              :: z-set from list
++|   %h-container-from-container
+  ++  h-silt                                              :: h-set from list
     |*  a=(list)
     =+  b=*(tree _?>(?=(^ a) i.a))
-    (~(gas z-in b) a)
+    (~(gas h-in b) a)
   ::
-  ++  z-molt                                              :: z-map from pair
+  ++  h-molt                                              :: h-map from pair
       |*  a=(list (pair))
-      (~(gas z-by `(tree [p=_p.i.-.a q=_q.i.-.a])`~) a)
+      (~(gas h-by `(tree [p=_p.i.-.a q=_q.i.-.a])`~) a)
   ::
-  ++  z-malt                                              ::  z-map from list
+  ++  h-malt                                              ::  h-map from list
   |*  a=(list)
-  (z-molt `(list [p=_-<.a q=_->.a])`a)
+  (h-molt `(list [p=_-<.a q=_->.a])`a)
 --

--- a/hoon/common/h-zoon.hoon
+++ b/hoon/common/h-zoon.hoon
@@ -9,10 +9,7 @@
 ++  ju  %do-not-use
 ++  ja  %do-not-use
 ++  bi  %do-not-use
-+$  hashed
-  $?  noun-digest:tip5:z
-      noun-digests:z
-  ==
++$  hashed  $^(noun-digests:z noun-digest:tip5:z)
 ::
 +|  %map
 ++  h-map
@@ -652,9 +649,7 @@
 ++  hashed-to-digests
   |=  a=hashed
   ^-  noun-digests:z
-  ?:  ?=(@ a)
-    ~
-  ?:  ?=(@ -.a)
+  ?:  ?=([@ @ @ @ @] a)
     [a ~]
   a
 ::

--- a/hoon/common/tx-engine-0.hoon
+++ b/hoon/common/tx-engine-0.hoon
@@ -266,7 +266,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [hash+(hash:schnorr-pubkey p.n.form) (hashable:schnorr-signature q.n.form)]
       $(form l.form)
     $(form r.form)
@@ -541,7 +541,7 @@
   ++  hashable-tx-ids
     |=  tx-ids=(z-set tx-id)
     ^-  hashable:tip5
-    ?~  tx-ids  leaf+tx-ids
+    ?@  tx-ids  leaf+tx-ids
     :+  hash+n.tx-ids
       $(tx-ids l.tx-ids)
     $(tx-ids r.tx-ids)
@@ -943,7 +943,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [(hashable:nname p.n.form) (hashable:input q.n.form)]
       $(form l.form)
     $(form r.form)
@@ -1609,7 +1609,7 @@
     ++  hashable-pubkeys
       |=  pubkeys=(z-set schnorr-pubkey)
       ^-  hashable:tip5
-      ?~  pubkeys  leaf+pubkeys
+      ?@  pubkeys  leaf+pubkeys
       :+  hash+(hash:schnorr-pubkey n.pubkeys)
         $(pubkeys l.pubkeys)
       $(pubkeys r.pubkeys)
@@ -1844,7 +1844,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [(hashable:sig p.n.form) leaf+q.n.form]
       $(form l.form)
     $(form r.form)
@@ -2018,7 +2018,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  (hashable:seed n.form)
       $(form l.form)
     $(form r.form)
@@ -2026,7 +2026,7 @@
   ++  sig-hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  (sig-hashable:seed n.form)
       $(form l.form)
     $(form r.form)

--- a/hoon/common/tx-engine-1.hoon
+++ b/hoon/common/tx-engine-1.hoon
@@ -1,6 +1,6 @@
 /=  v0  /common/tx-engine-0
 /=  *  /common/zeke
-/=  *  /common/zoon
+/=  *  /common/h-zoon
 |%
 ::  import
 ++  hash  hash:v0
@@ -837,7 +837,7 @@
     (gth data-size max)
   ::
   ++  validate-with-context
-    |=  $:  balance=(z-map nname nnote)
+    |=  $:  balance=(h-map nname nnote)
             sps=form
             page-num=page-number
             max-size=@
@@ -849,7 +849,7 @@
     %+  roll  ~(tap z-by sps)
     |=  [[nam=nname sp=spend] acc=(reason ~)]
     ?.  ?=(%.y -.acc)  acc
-    =/  mnote=(unit nnote)  (~(get z-by balance) nam)
+    =/  mnote=(unit nnote)  (~(get h-by balance) nam)
     ?~  mnote  [%.n %v1-input-missing]
     =/  note=nnote  u.mnote
     ?-    -.sp

--- a/hoon/common/tx-engine-1.hoon
+++ b/hoon/common/tx-engine-1.hoon
@@ -91,7 +91,7 @@
   ++  hashable-tx-ids
     |=  tx-ids=(z-set tx-id)
     ^-  hashable:tip5
-    ?~  tx-ids  leaf+tx-ids
+    ?@  tx-ids  leaf+tx-ids
     :+  hash+n.tx-ids
       $(tx-ids l.tx-ids)
     $(tx-ids r.tx-ids)
@@ -279,7 +279,7 @@
     |=  =form
     |^
       ^-  ?
-      %-  ~(rep by form)
+      %-  ~(rep z-by form)
       |=  [[k=@tas v=*] a=?]
       ?&(a (^based k) (based-noun v))
     ++  based-noun
@@ -291,7 +291,7 @@
     |=  =form
     ^-  hashable:tip5
     |^
-      ?~  form  leaf+~
+      ?@  form  leaf+~
       :+  [leaf+p.n.form (hashable-noun q.n.form)]
         $(form l.form)
       $(form r.form)
@@ -394,7 +394,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+~
+    ?@  form  leaf+~
     :+  (hashable:seed n.form)
       $(form l.form)
     $(form r.form)
@@ -402,7 +402,7 @@
   ++  sig-hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  (sig-hashable:seed n.form)
       $(form l.form)
     $(form r.form)
@@ -553,7 +553,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [hash+p.n.form leaf+q.n.form]
       $(form l.form)
     $(form r.form)
@@ -789,7 +789,7 @@
     |=  =form
     ^-  hashable:tip5
     |-
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [(hashable:nname p.n.form) (hashable:spend q.n.form)]
       $(form l.form)
     $(form r.form)
@@ -993,7 +993,7 @@
   ++  hashable
     |=  =form
     ^-  hashable:tip5
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [(hashable:nname p.n.form) (hashable:input q.n.form)]
       $(form l.form)
     $(form r.form)
@@ -1227,7 +1227,7 @@
   ++  hashable-hax
     |=  m=(z-map ^hash *)
     ^-  hashable:tip5
-    ?~  m  leaf+m
+    ?@  m  leaf+m
     :+  [hash+p.n.m (hashable-noun q.n.m)]
         $(m l.m)
     $(m r.m)
@@ -1649,7 +1649,7 @@
     ++  hashable-hashes
       |=  hs=(z-set ^hash)
       ^-  hashable:tip5
-      ?~  hs  leaf+hs
+      ?@  hs  leaf+hs
       :+  hash+n.hs
         $(hs l.hs)
       $(hs r.hs)
@@ -1690,7 +1690,7 @@
     based:^hash
   ++  hashable
     |=  =form
-    ?~  form  leaf+~
+    ?@  form  leaf+~
     :*  hash+n.form
         $(form l.form)
         $(form r.form)
@@ -1780,7 +1780,7 @@
     |=  =form
     ^-  hashable:tip5
     |^
-    ?~  form  leaf+form
+    ?@  form  leaf+form
     :+  [hash+p.n.form (hashable-val q.n.form)]
       $(form l.form)
     $(form r.form)

--- a/hoon/common/tx-engine.hoon
+++ b/hoon/common/tx-engine.hoon
@@ -1173,9 +1173,9 @@
       [%.y f(balance (~(put h-by balance.f) name.note.op note.op))]
     ::
     ++  consume-inputs
-      |=  [ips=(h-map nname input:v0) page-num=page-number]
+      |=  [ips=(z-map nname input:v0) page-num=page-number]
       ^-  (reason [timelock-range ^form])
-      %+  roll  ~(val h-by ips)
+      %+  roll  ~(val z-by ips)
       |:  :*  ip=*input:v0
               acc=`(reason [timelock-range ^form])`[%.y *timelock-range form]
           ==

--- a/hoon/common/tx-engine.hoon
+++ b/hoon/common/tx-engine.hoon
@@ -1,7 +1,7 @@
 /=  v0  /common/tx-engine-0
 /=  v1  /common/tx-engine-1
 /=  *  /common/zeke
-/=  *  /common/zoon
+/=  *  /common/h-zoon
 /=  *  /common/zose
 =>  |%
     ++  blockchain-constants  blockchain-constants:v1
@@ -1059,7 +1059,7 @@
 ++  txs
   =<  form
   |%
-  +$  form  (z-map tx-id tx)
+  +$  form  (h-map tx-id tx)
   --
 ::
 ::  $tx-acc: accumulate transactions against a balance to create a new balance
@@ -1067,26 +1067,26 @@
   =<  form
   |%
   +$  form
-    $:  balance=(z-map nname nnote)                     ::  current balance
+    $:  balance=(h-map nname nnote)                     ::  current balance
         height=page-number                              ::  origin height
         fees=coins                                      ::  total fee
         =size                                           ::  total size
         =txs                                            ::  valid txs
     ==
   ++  new
-    |=  $:  initial-balance=(unit (z-map nname nnote))
+    |=  $:  initial-balance=(unit (h-map nname nnote))
             initial-height=page-number
         ==
     ^-  form
     %*  .  *form
-      balance  ?~  initial-balance  *(z-map nname nnote)
+      balance  ?~  initial-balance  *(h-map nname nnote)
                u.initial-balance
       height   initial-height
     ==
   ::
   ++  txs-size-by-set
     |=  form
-    %-  ~(rep z-by txs)
+    %-  ~(rep h-by txs)
     |=  [[=tx-id =tx] sum-sizes=^size]
     %+  add  sum-sizes
     ~(size get:raw-tx raw-tx.tx)
@@ -1158,7 +1158,7 @@
     :-  %.y
     %_  form
       size  (add size.form computed-size)
-      txs   (~(put z-by txs.form) id.tx0 agg-tx)
+      txs   (~(put h-by txs.form) id.tx0 agg-tx)
     ==
     ::
     ++  add-outputs
@@ -1168,20 +1168,20 @@
       |:  [op=*output:v0 acc=`(reason _form)`[%.y form]]
       ?.  ?=(%.y -.acc)  acc
       =/  f=_form  p.acc
-      ?:  (~(has z-by balance.f) name.note.op)
+      ?:  (~(has h-by balance.f) name.note.op)
         [%.n %v0-output-already-exists]
-      [%.y f(balance (~(put z-by balance.f) name.note.op note.op))]
+      [%.y f(balance (~(put h-by balance.f) name.note.op note.op))]
     ::
     ++  consume-inputs
-      |=  [ips=(z-map nname input:v0) page-num=page-number]
+      |=  [ips=(h-map nname input:v0) page-num=page-number]
       ^-  (reason [timelock-range ^form])
-      %+  roll  ~(val z-by ips)
+      %+  roll  ~(val h-by ips)
       |:  :*  ip=*input:v0
               acc=`(reason [timelock-range ^form])`[%.y *timelock-range form]
           ==
       ?.  ?=(%.y -.acc)  acc
       =/  [tir=timelock-range f=^form]  p.acc
-      ?.  =(`note.ip (~(get z-by balance.f) name.note.ip))
+      ?.  =(`note.ip (~(get h-by balance.f) name.note.ip))
         [%.n %v0-input-missing]
       =/  new-tir=timelock-range
         %+  merge:timelock-range  tir
@@ -1191,7 +1191,7 @@
       :-  %.y
       :-  new-tir
       %_  f
-        balance  (~(del z-by balance.f) name.note.ip)
+        balance  (~(del h-by balance.f) name.note.ip)
         fees     (add fees.f fee.spend.ip)
       ==
     --
@@ -1225,7 +1225,7 @@
     :-  %.y
     %_  form
       size  (add size.form ~(size get:raw-tx raw1))
-      txs   (~(put z-by txs.form) (compute-id:raw-tx raw1) tx1)
+      txs   (~(put h-by txs.form) (compute-id:raw-tx raw1) tx1)
     ==
     ::
     ++  add-outputs
@@ -1238,9 +1238,9 @@
       =/  note=nnote  note.op
       ?.  ?=(@ -.note)  [%.n %v1-output-wrong-note-version]
       =/  nam=nname  name.note
-      ?:  (~(has z-by balance.f) nam)
+      ?:  (~(has h-by balance.f) nam)
         [%.n %v1-output-already-exists]
-      [%.y f(balance (~(put z-by balance.f) nam note))]
+      [%.y f(balance (~(put h-by balance.f) nam note))]
     ::
     ++  consume-inputs
       |=  sps=spends
@@ -1251,9 +1251,9 @@
         |:  [nam=*nname acc=`(reason ^form)`[%.y form]]
         ?.  ?=(%.y -.acc)  acc
         =/  f=^form  p.acc
-        ?.  (~(has z-by balance.f) nam)
+        ?.  (~(has h-by balance.f) nam)
           [%.n %v1-input-missing]
-        [%.y f(balance (~(del z-by balance.f) nam))]
+        [%.y f(balance (~(del h-by balance.f) nam))]
       ?.  ?=(%.y -.remove-result)  remove-result
       [%.y p.remove-result(fees (add fees.p.remove-result fees-add))]
     --

--- a/hoon/common/zoon.hoon
+++ b/hoon/common/zoon.hoon
@@ -3,28 +3,34 @@
 ~%  %zoon  ..stark-engine-jet-hook:z  ~
 |%
 ::
-+|  %no-by-in
-++  by  %do-not-use
-++  in  %do-not-use
-++  ju  %do-not-use
-++  ja  %do-not-use
-++  bi  %do-not-use
++|  %types
+:: NOTE: empty-checking with ?~ does not work due to %ztree. Use ?@.
+++  ztree
+  |$  [item]
+  $~  ~
+  $|  $@(?(%~ %ztree) [n=item l=(ztree item) r=(ztree item)])
+  |=  a=$@(?(%~ %ztree) [n=* l=(ztree) r=(ztree)])
+  |-  ^-  ?
+  ?@  a  =(~ a)
+  ?&  $(a l.a)
+      $(a r.a)
+  ==
 ::
 +|  %map
 ++  z-map
   |$  [key value]                                       ::  table
-  $|  (tree (pair key value))
-  |=(a=(tree (pair)) ?:(=(~ a) & ~(apt z-by a)))
+  $|  (ztree (pair key value))
+  |=(a=(ztree (pair)) ?@(a =(~ a) ~(apt z-by a)))
 ::
 ++  z-by                                                  ::  z-map engine
   ~/  %z-by
-  =|  a=(tree (pair))  ::  (z-map)
+  =|  a=(ztree (pair))  ::  (z-map)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       &
     ?&((b q.n.a) $(a l.a) $(a r.a))
   ::
@@ -32,7 +38,7 @@
     ~/  %any
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       |
     ?|((b q.n.a) $(a l.a) $(a r.a))
   ::
@@ -40,7 +46,7 @@
     ~/  %bif
     |*  b=*
     |-  ^+  [l=a r=a]
-    ?~  a
+    ?@  a
       [~ ~]
     ?:  =(b p.n.a)
       +.a
@@ -56,15 +62,15 @@
     ~/  %del
     |*  b=*
     |-  ^+  a
-    ?~  a
+    ?@  a
       ~
     ?.  =(b p.n.a)
       ?:  (gor-tip b p.n.a)
         a(l $(a l.a))
       a(r $(a r.a))
-    |-  ^-  [$?(~ _a)]
-    ?~  l.a  r.a
-    ?~  r.a  l.a
+    |-  ^-  [$?(?(%~ %ztree) _a)]
+    ?@  l.a  r.a
+    ?@  r.a  l.a
     ?:  (mor-tip p.n.l.a p.n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
@@ -73,15 +79,15 @@
     ~/  %dif
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     =+  c=(bif p.n.b)
     ?>  ?=(^ c)
     =+  d=$(a l.c, b l.b)
     =+  e=$(a r.c, b r.b)
-    |-  ^-  [$?(~ _a)]
-    ?~  d  e
-    ?~  e  d
+    |-  ^-  [$?(?(%~ %ztree) _a)]
+    ?@  d  e
+    ?@  e  d
     ?:  (mor-tip p.n.d p.n.e)
       d(r $(d r.d))
     e(l $(e l.e))
@@ -91,7 +97,7 @@
     |=  b=*
     =+  c=1
     |-  ^-  (unit @)
-    ?~  a  ~
+    ?@  a  ~
     ?:  =(b p.n.a)  [~ u=(peg c 2)]
     ?:  (gor-tip b p.n.a)
       $(a l.a, c (peg c 6))
@@ -101,12 +107,12 @@
     =<  $
     =|  [l=(unit) r=(unit)]
     |.  ^-  ?
-    ?~  a   &
+    ?@  a   =(~ a)
     ?&  ?~(l & &((gor-tip p.n.a u.l) !=(p.n.a u.l)))
         ?~(r & &((gor-tip u.r p.n.a) !=(u.r p.n.a)))
-        ?~  l.a   &
+        ?@  l.a   &
         &((mor-tip p.n.a p.n.l.a) !=(p.n.a p.n.l.a) $(a l.a, l `p.n.a))
-        ?~  r.a   &
+        ?@  r.a   &
         &((mor-tip p.n.a p.n.r.a) !=(p.n.a p.n.r.a) $(a r.a, r `p.n.a))
     ==
   ::
@@ -115,7 +121,7 @@
     |*  b=(list [p=* q=*])
     =>  .(b `(list _?>(?=(^ a) n.a))`b)
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
@@ -124,7 +130,7 @@
     |*  b=*
     =>  .(b `_?>(?=(^ a) p.n.a)`b)
     |-  ^-  (unit _?>(?=(^ a) q.n.a))
-    ?~  a
+    ?@  a
       ~
     ?:  =(b p.n.a)
       (some q.n.a)
@@ -151,9 +157,9 @@
     ~/  %int
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       ~
-    ?~  a
+    ?@  a
       ~
     ?:  (mor-tip p.n.a p.n.b)
       ?:  =(p.n.b p.n.a)
@@ -172,7 +178,7 @@
     |*  [key=_?>(?=(^ a) p.n.a) fun=$-(_?>(?=(^ a) q.n.a) _?>(?=(^ a) q.n.a))]
     ^+  a
     ::
-    ?~  a  !!
+    ?@  a  !!
     ::
     ?:  =(key p.n.a)
       a(q.n (fun q.n.a))
@@ -193,7 +199,7 @@
     ~/  %put
     |*  [b=* c=*]
     |-  ^+  a
-    ?~  a
+    ?@  a
       [[b c] ~ ~]
     ?:  =(b p.n.a)
       ?:  =(c q.n.a)
@@ -215,14 +221,14 @@
     ~/  %rep
     |*  b=_=>(~ |=([* *] +<+))
     |-
-    ?~  a  +<+.b
+    ?@  a  +<+.b
     $(a r.a, +<+.b $(a l.a, +<+.b (b n.a +<+.b)))
   ::
   ++  rib                                               ::  transform + product
     ~/  %rib
     |*  [b=* c=gate]
     |-  ^+  [b a]
-    ?~  a  [b ~]
+    ?@  a  [b ~]
     =+  d=(c n.a b)
     =.  n.a  +.d
     =+  e=$(a l.a, b -.d)
@@ -233,14 +239,14 @@
     ~/  %run
     |*  b=gate
     |-
-    ?~  a  a
+    ?@  a  a
     [n=[p=p.n.a q=(b q.n.a)] l=$(a l.a) r=$(a r.a)]
   ::
   ++  tap                                               ::  listify pairs
     =<  $
     =+  b=`(list _?>(?=(^ a) n.a))`~
     |.  ^+  b
-    ?~  a
+    ?@  a
       b
     $(a r.a, b [n.a $(a l.a)])
   ::
@@ -248,9 +254,9 @@
     ~/  %uni
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
-    ?~  a
+    ?@  a
       b
     ?:  =(p.n.b p.n.a)
       b(l $(a l.a, b l.b), r $(a r.a, b r.b))
@@ -267,9 +273,9 @@
     |*  b=_a
     |*  meg=$-([* * *] *)
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
-    ?~  a
+    ?@  a
       b
     ?:  =(p.n.b p.n.a)
       :+  [p.n.a `_?>(?=(^ a) q.n.a)`(meg p.n.a q.n.a q.n.b)]
@@ -287,40 +293,40 @@
     ~/  %urn
     |*  b=$-([* *] *)
     |-
-    ?~  a  ~
+    ?@  a  ~
     a(n n.a(q (b p.n.a q.n.a)), l $(a l.a), r $(a r.a))
   ::
   ++  wyt                                               ::  depth of z-map
     =<  $
     |.  ^-  @
-    ?~(a 0 +((add $(a l.a) $(a r.a))))
+    ?@(a 0 +((add $(a l.a) $(a r.a))))
   ::
   ++  key                                               ::  z-set of keys
     |-  ^-  (z-set _?>(?=(^ a) p.n.a))
-    ?~  a  ~
+    ?@  a  ~
     [p.n.a $(a l.a) $(a r.a)]
   ::
   ++  val                                               ::  list of vals
     =+  b=`(list _?>(?=(^ a) q.n.a))`~
     |-  ^+  b
-    ?~  a   b
+    ?@  a   b
     $(a r.a, b [q.n.a $(a l.a)])
   --
 +|  %set
 ++  z-set
   |$  [item]                                            ::  z-set
-  $|  (tree item)
-  |=(a=(tree) ?:(=(~ a) & ~(apt z-in a)))
+  $|  (ztree item)
+  |=(a=(ztree) ?@(a =(~ a) ~(apt z-in a)))
 ::
 ++  z-in                                                  ::  z-set engine
   ~/  %z-in
-  =|  a=(tree)  :: (z-set)
+  =|  a=(ztree)  :: (z-set)
   |@
   ++  all                                               ::  logical AND
     ~/  %all
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       &
     ?&((b n.a) $(a l.a) $(a r.a))
   ::
@@ -328,7 +334,7 @@
     ~/  %any
     |*  b=$-(* ?)
     |-  ^-  ?
-    ?~  a
+    ?@  a
       |
     ?|((b n.a) $(a l.a) $(a r.a))
   ::
@@ -336,11 +342,11 @@
     =<  $
     =|  [l=(unit) r=(unit)]
     |.  ^-  ?
-    ?~  a   &
+    ?@  a   =(~ a)
     ?&  ?~(l & &((gor-tip n.a u.l) !=(n.a u.l)))
         ?~(r & &((gor-tip u.r n.a) !=(u.r n.a)))
-        ?~(l.a & ?&((mor-tip n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
-        ?~(r.a & ?&((mor-tip n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
+        ?@(l.a & ?&((mor-tip n.a n.l.a) !=(n.a n.l.a) $(a l.a, l `n.a)))
+        ?@(r.a & ?&((mor-tip n.a n.r.a) !=(n.a n.r.a) $(a r.a, r `n.a)))
     ==
   ::
   ++  bif                                               ::  splits a by b
@@ -349,7 +355,7 @@
     ^+  [l=a r=a]
     =<  +
     |-  ^+  a
-    ?~  a
+    ?@  a
       [b ~ ~]
     ?:  =(b n.a)
       a
@@ -365,15 +371,15 @@
     ~/  %del
     |*  b=*
     |-  ^+  a
-    ?~  a
+    ?@  a
       ~
     ?.  =(b n.a)
       ?:  (gor-tip b n.a)
         a(l $(a l.a))
       a(r $(a r.a))
-    |-  ^-  [$?(~ _a)]
-    ?~  l.a  r.a
-    ?~  r.a  l.a
+    |-  ^-  [$?(?(%~ %ztree) _a)]
+    ?@  l.a  r.a
+    ?@  r.a  l.a
     ?:  (mor-tip n.l.a n.r.a)
       l.a(r $(l.a r.l.a))
     r.a(l $(r.a l.r.a))
@@ -382,15 +388,15 @@
     ~/  %dif
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     =+  c=(bif n.b)
     ?>  ?=(^ c)
     =+  d=$(a l.c, b l.b)
     =+  e=$(a r.c, b r.b)
-    |-  ^-  [$?(~ _a)]
-    ?~  d  e
-    ?~  e  d
+    |-  ^-  [$?(?(%~ %ztree) _a)]
+    ?@  d  e
+    ?@  e  d
     ?:  (mor-tip n.d n.e)
       d(r $(d r.d))
     e(l $(e l.e))
@@ -400,7 +406,7 @@
     |=  b=*
     =+  c=1
     |-  ^-  (unit @)
-    ?~  a  ~
+    ?@  a  ~
     ?:  =(b n.a)  [~ u=(peg c 2)]
     ?:  (gor-tip b n.a)
       $(a l.a, c (peg c 6))
@@ -410,7 +416,7 @@
     ~/  %gas
     |=  b=(list _?>(?=(^ a) n.a))
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     $(b t.b, a (put i.b))
   ::  +has: does :b exist z-in :a?
@@ -434,7 +440,7 @@
     |=  b=(unit _?>(?=(^ a) n.a))
     =>  .(b ?>(?=(^ b) u.b))
     |-  ^-  ?
-    ?~  a
+    ?@  a
       |
     ?:  =(b n.a)
       &
@@ -446,9 +452,9 @@
     ~/  %int
     |*  b=_a
     |-  ^+  a
-    ?~  b
+    ?@  b
       ~
-    ?~  a
+    ?@  a
       ~
     ?.  (mor-tip n.a n.b)
       $(a b, b a)
@@ -462,7 +468,7 @@
     ~/  %put
     |*  b=*
     |-  ^+  a
-    ?~  a
+    ?@  a
       [b ~ ~]
     ?:  =(b n.a)
       a
@@ -482,14 +488,14 @@
     ~/  %rep
     |*  b=_=>(~ |=([* *] +<+))
     |-
-    ?~  a  +<+.b
+    ?@  a  +<+.b
     $(a r.a, +<+.b $(a l.a, +<+.b (b n.a +<+.b)))
   ::
   ++  run                                               ::  apply gate to values
     ~/  %run
     |*  b=gate
     =+  c=`(z-set _?>(?=(^ a) (b n.a)))`~
-    |-  ?~  a  c
+    |-  ?@  a  c
     =.  c  (~(put z-in c) (b n.a))
     =.  c  $(a l.a, c c)
     $(a r.a, c c)
@@ -498,7 +504,7 @@
     =<  $
     =+  b=`(list _?>(?=(^ a) n.a))`~
     |.  ^+  b
-    ?~  a
+    ?@  a
       b
     $(a r.a, b [n.a $(a l.a)])
   ::
@@ -507,9 +513,9 @@
     |*  b=_a
     ?:  =(a b)  a
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
-    ?~  a
+    ?@  a
       b
     ?:  =(n.b n.a)
       b(l $(a l.a, b l.b), r $(a r.a, b r.b))
@@ -524,7 +530,7 @@
   ++  wyt                                               ::  size of z-set
     =<  $
     |.  ^-  @
-    ?~(a 0 +((add $(a l.a) $(a r.a))))
+    ?@(a 0 +((add $(a l.a) $(a r.a))))
   --
 +|  %mip
 ::
@@ -539,7 +545,7 @@
     |*  [b=* c=*]
     =+  d=(~(gut z-by a) b ~)
     =+  e=(~(del z-by d) c)
-    ?~  e
+    ?@  e
       (~(del z-by a) b)
     (~(put z-by a) b e)
   ::
@@ -577,7 +583,7 @@
     =<  $
     =+  b=`_?>(?=(^ a) *(list [x=_p.n.a _?>(?=(^ q.n.a) [y=p v=q]:n.q.n.a)]))`~
     |.  ^+  b
-    ?~  a
+    ?@  a
       b
     $(a r.a, b (welp (turn ~(tap z-by q.n.a) (lead p.n.a)) $(a l.a)))
   --
@@ -589,14 +595,14 @@
   (z-map key (z-set value))
 ::
 ++  z-ju                                                ::  z-jug engine
-  =|  a=(tree (pair * (tree)))                          ::  (z-jug)
+  =|  a=(z-map * (z-set))                               ::  (z-jug)
   |@
   ++  del                                               ::  del key-set pair
     |*  [b=* c=*]
     ^+  a
     =+  d=(get b)
     =+  e=(~(del z-in d) c)
-    ?~  e
+    ?@  e
       (~(del z-by a) b)
     (~(put z-by a) b e)
   ::
@@ -604,14 +610,14 @@
     |*  b=(list [p=* q=*])
     =>  .(b `(list _?>(?=([[* ^] ^] a) [p=p q=n.q]:n.a))`b)
     |-  ^+  a
-    ?~  b
+    ?@  b
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
   ++  get                                               ::  gets z-set by key
     |*  b=*
     =+  c=(~(get z-by a) b)
-    ?~(c ~ u.c)
+    ?@(c ~ u.c)
   ::
   ++  has                                               ::  existence check
     |*  [b=* c=*]
@@ -687,12 +693,12 @@
 +|   %z-container-from-container
   ++  z-silt                                              :: z-set from list
     |*  a=(list)
-    =+  b=*(tree _?>(?=(^ a) i.a))
+    =+  b=*(ztree _?>(?=(^ a) i.a))
     (~(gas z-in b) a)
   ::
   ++  z-molt                                              :: z-map from pair
       |*  a=(list (pair))
-      (~(gas z-by `(tree [p=_p.i.-.a q=_q.i.-.a])`~) a)
+      (~(gas z-by `(ztree [p=_p.i.-.a q=_q.i.-.a])`~) a)
   ::
   ++  z-malt                                              ::  z-map from list
   |*  a=(list)

--- a/hoon/common/zoon.hoon
+++ b/hoon/common/zoon.hoon
@@ -1,5 +1,5 @@
 ::  /lib/zoon: vendored types from hoon.hoon
-/=  *  /common/h-zoon
+/=  z  /common/zeke
 ~%  %zoon  ..stark-engine-jet-hook:z  ~
 |%
 ::


### PR DESCRIPTION
Initial `h-map`/`h-set`/`h-mip`/`h-etc.` data structures

We're using very particular `gor-hip`, `mor-hip` that convert `noun-digest` to `noun-digests` in nock, however, one could imagine jets skipping this part upon discriminating the the single/multi digest cases.