### PR TITLE
fix(nockup): pin `basic` template's nockchain deps to a real commit / proposed addition to nockup architecture

### DIFF
--- a/crates/nockup/templates/basic/Cargo.toml
+++ b/crates/nockup/templates/basic/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/main.rs"
 
 [dependencies]
 # NockVM dependency
-nockapp = { git = "https://github.com/nockchain/nockchain.git", rev = "{{nockapp_commit_hash}}" }
-nockvm = { git = "https://github.com/nockchain/nockchain.git", rev = "{{nockapp_commit_hash}}" }
-nockvm_macros = { git = "https://github.com/nockchain/nockchain.git", rev = "{{nockapp_commit_hash}}" }
+nockapp = { git = "https://github.com/nockchain/nockchain.git", rev = "485e914b389a1e518d4aaaa24f5f079d0ad894be" }
+nockvm = { git = "https://github.com/nockchain/nockchain.git", rev = "485e914b389a1e518d4aaaa24f5f079d0ad894be" }
+nockvm_macros = { git = "https://github.com/nockchain/nockchain.git", rev = "485e914b389a1e518d4aaaa24f5f079d0ad894be" }
 
 # Common dependencies for NockApps
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
# fix(nockup): pin `basic` template's nockchain deps to a real commit / proposed addition to nockup architecture

## Problem

On current `master`, a fresh project scaffolded from the default `basic`
template can't compile because its `Cargo.toml` lands with an empty git
revision:

```console
$ cat > nockapp.toml <<EOF
[package]
name = "demo"
version = "0.1.0"
template = "basic"
EOF
$ nockup project init
$ cd demo && cargo +nightly check
error: failed to get `nockapp` as a dependency of package `demo v0.1.0`
Caused by: unable to update https://github.com/nockchain/nockchain.git?rev=
Caused by: failed to parse revision specifier - Invalid pattern ''
```

The three nockchain git deps in `crates/nockup/templates/basic/Cargo.toml`
are written as:

```toml
nockapp = { git = "https://github.com/nockchain/nockchain.git", rev = "{{nockapp_commit_hash}}" }
```

`{{nockapp_commit_hash}}` is a Handlebars variable that the modern
`project init` flow's context builder in
`crates/nockup/src/commands/build/init.rs:89-106` doesn't populate, so
Handlebars renders it as the empty string. The legacy `nockup init`
flow in `src/commands/init.rs` does set the variable (from a
project-level TOML field), but that flow isn't what `nockup project
init` takes today.

## Fix

Replace the Handlebars variable with a literal commit hash, matching
what every other template in the directory already does:

- `templates/grpc/Cargo.toml` pins `485e914…`
- `templates/http-server/Cargo.toml`, `http-static`, `repl` pin
  `336f744…`

This PR aligns `basic` with `grpc`'s pinned commit — the most recent
of the two across the directory. One file, three lines.

## Verification

```console
$ nockup project init
$ cd demo && cargo +nightly check
# ... downloads happen ...
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

Exit 0 with only two unused-import warnings from the template's own
`main.rs` (unrelated to this change).

## Notes

- Same scaffold-side Handlebars gap also affects `{{author_name}}` and
  `{{author_email}}` — the modern init context has an `author` key but
  not the split form the template expects. That renders as `authors =
  [" <>"]` in the scaffolded `Cargo.toml`. Cosmetic, valid TOML,
  doesn't break build — not addressed here.
- A cleaner long-term fix would be to populate `nockapp_commit_hash`
  at nockup build time (e.g., via `build.rs` reading `git rev-parse
  HEAD`) so `basic` stays pinned to whatever nockchain was current
  when the user's nockup was built. Worth considering separately; the
  pinned-literal form above matches the rest of the directory and
  unbreaks the scaffold today.

---

### Separately: a related gap you might want addressed

This fix came out of first-pass friction while building a package for
the nockup library. The harder problem I ran into after: as soon as
the package needs anything Rust-side — a Cargo dependency, a `[patch]`
block, a specific `build.rs` shape — there's no way for the package
to declare those edits. They have to live in the README and rely on
users to apply them by hand.

I'd like to offer a `[[patches]]` field on the package manifest, with
four declarative ops — `overwrite`, `replace_pattern`,
`ensure_dependency`, `ensure_patch` — applied by `nockup package
install` with an interactive y/N confirmation and a lockfile-backed
ledger. All idempotent; all refuse rather than overwrite when a
consumer's file has diverged from what the ledger expects. No
arbitrary code execution.

## UPDATE

This has been submitted as PR 117