### PR TITLE
feat(nockup): declarative post-install [[patches]]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,6 +5668,7 @@ dependencies = [
  "openssl-sys",
  "predicates",
  "proptest",
+ "regex",
  "reqwest",
  "semver 1.0.27",
  "serde",
@@ -5678,6 +5679,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.22.27",
  "which 8.0.2",
 ]
 
@@ -6602,7 +6604,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -8640,6 +8642,12 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
@@ -8654,6 +8662,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -8676,6 +8696,12 @@ checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ rand = { version = "0.9.2", features = ["std"] }
 ratatui = "0.29.0"
 rayon = "1.8.0"
 rcgen = "0.14.3"
+regex = "1.10"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "http2",
@@ -151,6 +152,7 @@ tokio-rustls = "0.26.0"
 tokio-stream = "0.1"
 tokio-util = "0.7.11"
 toml = "0.9.8"
+toml_edit = "0.22"
 tonic = { version = "0.14.0", features = ["tls-webpki-roots"] }
 tonic-build = "0.14"
 tonic-health = "0.14.2"

--- a/DECISIONS/0003-merge-master-into-long-running-branches.md
+++ b/DECISIONS/0003-merge-master-into-long-running-branches.md
@@ -1,0 +1,49 @@
+# ADR 0003: Merge Master Into Long-Running Feature Branches
+
+Status: accepted
+Date: 2026-05-03
+Owners: @sobchek
+Supersedes: none
+Superseded by: none
+Related:
+- [START_HERE](../START_HERE.md)
+- [WORKFLOWS](../WORKFLOWS.md)
+- [DECISIONS index](./README.md)
+
+## Context
+
+Long-running feature branches (the first concrete case is `feat/package-patches`, PR #117) accumulate commits while master keeps moving. Master's dependency churn — workspace deps, new crates, version pins — frequently produces conflicts in `Cargo.lock`, which cannot auto-merge because both sides modify the same lines from the merge base.
+
+When the conflict surfaces, contributors face two choices:
+
+- **Rebase** the feature branch onto master: linear history, but rewrites commit hashes and breaks in-flight review continuity (existing PR comments lose anchor commits, force-push churn).
+- **Merge** master into the feature branch: preserves commit hashes and review continuity at the cost of a merge commit in history.
+
+## Decision
+
+For long-running feature branches that have accumulated review activity, **merge master in** rather than rebase.
+
+Resolve `Cargo.lock` by:
+
+1. Take master's lockfile: `git checkout --theirs -- Cargo.lock && git add Cargo.lock`.
+2. Re-run `cargo update --workspace` so the merged manifest's new entries (workspace deps added by the feature branch) are written to the lock without disturbing master's pins.
+3. Verify with `cargo check -p <feature-crate> --locked` before committing the merge.
+
+For short-lived branches with no review activity, rebase is still preferred.
+
+## Alternatives Considered
+
+1. **Always rebase.** Rejected for long-running PRs — disrupts review continuity and forces reviewers to re-orient against new commit hashes after every master sync.
+2. **Pre-emptively mirror master's `Cargo.lock` on the branch.** Rejected — fragile (requires re-syncing on every master lockfile change) and doesn't actually integrate master's manifest changes that the lock references.
+
+## Consequences
+
+- Positive: Review continuity preserved across master syncs.
+- Tradeoff: Merge commits appear in branch history.
+- Follow-on: Merge commit messages should record conflicted paths and resolution strategy so future readers can audit.
+
+## Rollout
+
+1. PR #117 (`feat/package-patches`) is the first branch to follow this convention; see merge commit `Merge master into feat/package-patches` (`ae71443`).
+2. New long-running branches: apply this policy on first conflict.
+3. Backout: revert the merge commit and rebase if review state allows.

--- a/DECISIONS/README.md
+++ b/DECISIONS/README.md
@@ -34,6 +34,7 @@ Canonical/Legacy: Canonical (ADR index for durable technical decisions)
 | ---- | ------------------------------- | -------- | ---------- | ---------- | -------------------------------------------------------------------------------------- |
 | 0001 | Doc Spine And Authority         | accepted | 2026-02-18 | none       | [`0001-doc-spine-and-authority.md`](./0001-doc-spine-and-authority.md)                 |
 | 0002 | Protocol-First Canonicalization | accepted | 2026-02-18 | none       | [`0002-protocol-first-canonicalization.md`](./0002-protocol-first-canonicalization.md) |
+| 0003 | Merge Master Into Long-Running Branches | accepted | 2026-05-03 | none       | [`0003-merge-master-into-long-running-branches.md`](./0003-merge-master-into-long-running-branches.md) |
 
 ## Add A New ADR
 

--- a/crates/nockup/Cargo.toml
+++ b/crates/nockup/Cargo.toml
@@ -36,6 +36,7 @@ hex = { workspace = true }
 once_cell = "1.20"
 openssl-sys = { version = "0.9", optional = true }
 proptest = "1.9.0"
+regex = { workspace = true }
 reqwest = { workspace = true }
 semver = "1.0"
 serde = { workspace = true, features = ["derive"] }
@@ -45,6 +46,7 @@ tar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "process"] }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 which = { workspace = true }
 
 [build-dependencies]

--- a/crates/nockup/src/cli.rs
+++ b/crates/nockup/src/cli.rs
@@ -28,6 +28,10 @@ pub enum Commands {
     #[command(subcommand)]
     Channel(ChannelCommand),
 
+    /// Manage post-install patches declared by installed packages.
+    #[command(subcommand)]
+    Patches(PatchesCommand),
+
     // Legacy flat commands (backward compatible)
     /// Build a NockApp project
     #[command(hide = true)]
@@ -100,7 +104,17 @@ pub enum PackageCommand {
     List,
 
     /// Install dependencies from nockapp.toml
-    Install,
+    Install {
+        /// Apply declared post-install patches without prompting (for CI).
+        #[arg(long)]
+        accept_patches: bool,
+        /// Plan patches but don't touch the filesystem.
+        #[arg(long)]
+        dry_run: bool,
+        /// Print the planned patch set.
+        #[arg(long)]
+        show_patches: bool,
+    },
 
     /// Update dependencies to latest versions
     Update,
@@ -143,4 +157,13 @@ pub enum CacheCommand {
 pub enum ChannelCommand {
     Show,
     Set { channel: String },
+}
+
+#[derive(clap::Subcommand, Debug)]
+pub enum PatchesCommand {
+    /// Drop a package's applied-patches ledger entries. Files on disk
+    /// stay as-they-are; a later install re-prompts.
+    Eject { package: String },
+    /// Print the applied-patches ledger for the current project.
+    List,
 }

--- a/crates/nockup/src/commands/build/build.rs
+++ b/crates/nockup/src/commands/build/build.rs
@@ -44,7 +44,10 @@ pub async fn run(project: &str) -> Result<()> {
             std::env::set_current_dir(project_dir)?;
 
             // Run package install
-            let install_result = crate::commands::package::install::run().await;
+            let install_result = crate::commands::package::install::run(
+                crate::commands::package::install::InstallOptions::default(),
+            )
+            .await;
 
             // Change back to original directory
             std::env::set_current_dir(original_dir)?;

--- a/crates/nockup/src/commands/build/init.rs
+++ b/crates/nockup/src/commands/build/init.rs
@@ -76,9 +76,11 @@ pub async fn run() -> Result<()> {
 
     println!("Running dependency installation…");
     // Package install will automatically detect the project directory based on manifest name
-    crate::commands::package::install::run()
-        .await
-        .context("Failed to install dependencies")?;
+    crate::commands::package::install::run(
+        crate::commands::package::install::InstallOptions::default(),
+    )
+    .await
+    .context("Failed to install dependencies")?;
 
     println!("\nAll done! Project is ready.");
     println!("   cd {}", project_name.cyan());

--- a/crates/nockup/src/commands/mod.rs
+++ b/crates/nockup/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod channel;
 pub mod common;
 pub mod init;
 pub mod package;
+pub mod patches;
 pub mod run;
 pub mod test_phase1;
 pub mod update;

--- a/crates/nockup/src/commands/package.rs
+++ b/crates/nockup/src/commands/package.rs
@@ -16,7 +16,18 @@ pub async fn run(cmd: PackageCommand) -> Result<()> {
         PackageCommand::Add { name, version } => add::run(name, version).await,
         PackageCommand::Remove { name } => remove::run(name).await,
         PackageCommand::List => list::run().await,
-        PackageCommand::Install => install::run().await,
+        PackageCommand::Install {
+            accept_patches,
+            dry_run,
+            show_patches,
+        } => {
+            install::run(install::InstallOptions {
+                accept_patches,
+                dry_run,
+                show_patches,
+            })
+            .await
+        }
         PackageCommand::Update => update::run().await,
         PackageCommand::Purge { dry_run } => purge::purge(dry_run).await,
         PackageCommand::Grab { .. } => {

--- a/crates/nockup/src/commands/package/init.rs
+++ b/crates/nockup/src/commands/package/init.rs
@@ -37,6 +37,7 @@ pub async fn run(name: Option<String>) -> Result<()> {
             template_commit: None,
         },
         dependencies: Some(Default::default()),
+        patches: Vec::new(),
     };
 
     pkg.save(&manifest_path)?;

--- a/crates/nockup/src/commands/package/install.rs
+++ b/crates/nockup/src/commands/package/install.rs
@@ -7,9 +7,18 @@ use colored::Colorize;
 
 use crate::cache::PackageCache;
 use crate::manifest::{HoonPackage, LockSource, LockedPackage, NockAppLock};
+use crate::patches::{self, PatchOptions};
 use crate::resolver::Resolver;
 
-pub async fn run() -> Result<()> {
+/// Install-time flags surfaced from the CLI.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InstallOptions {
+    pub accept_patches: bool,
+    pub dry_run: bool,
+    pub show_patches: bool,
+}
+
+pub async fn run(opts: InstallOptions) -> Result<()> {
     let cwd = env::current_dir()?;
     let manifest_path = cwd.join("nockapp.toml");
 
@@ -73,7 +82,10 @@ pub async fn run() -> Result<()> {
     fs::create_dir_all(&lib_dir).context("Failed to create hoon/lib directory")?;
     fs::create_dir_all(&sur_dir).context("Failed to create hoon/sur directory")?;
 
-    // Install packages in topological order
+    // Install packages in topological order. Seed `applied_patches`
+    // from the existing lockfile so re-installs don't lose the ledger.
+    let lock_path = project_dir.join("nockapp.lock");
+    let existing_lock = NockAppLock::load(&lock_path).unwrap_or(NockAppLock { package: vec![] });
     let mut locked_packages = Vec::new();
 
     for pkg_name in &graph.install_order {
@@ -156,7 +168,15 @@ pub async fn run() -> Result<()> {
             )?;
         }
 
-        // Add to lockfile
+        // Add to lockfile. `applied_patches` is seeded from the prior
+        // ledger so re-installs don't lose entries; the patch engine
+        // overwrites it below if it actually applies anything.
+        let prior_applied = existing_lock
+            .package
+            .iter()
+            .find(|p| p.name == pkg.name)
+            .map(|p| p.applied_patches.clone())
+            .unwrap_or_default();
         locked_packages.push(LockedPackage {
             name: pkg.name.clone(),
             version: display_version.clone(),
@@ -165,6 +185,7 @@ pub async fn run() -> Result<()> {
                 commit: pkg.commit.clone(),
                 path: pkg.source_path.clone(),
             },
+            applied_patches: prior_applied,
         });
     }
 
@@ -175,14 +196,133 @@ pub async fn run() -> Result<()> {
         graph.packages.len()
     );
 
+    // --- Post-install patches --------------------------------------------
+    let prior_ledger = |name: &str| -> Vec<crate::manifest::AppliedPatch> {
+        existing_lock
+            .package
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| p.applied_patches.clone())
+            .unwrap_or_default()
+    };
+
+    let patch_plan: Vec<(usize, &crate::resolver::types::ResolvedPackage)> = locked_packages
+        .iter()
+        .enumerate()
+        .filter_map(|(i, locked)| {
+            graph
+                .packages
+                .get(&locked.name)
+                .filter(|pkg| !pkg.patches.is_empty())
+                .map(|pkg| (i, pkg))
+        })
+        .collect();
+
+    if !patch_plan.is_empty() {
+        let summary: String = patch_plan
+            .iter()
+            .map(|(_, pkg)| patches::summarize(&project_dir, &pkg.name, &pkg.patches))
+            .collect();
+
+        if opts.show_patches {
+            println!();
+            println!("{}", "Planned patches:".bold());
+            print!("{}", summary);
+        }
+
+        #[derive(PartialEq)]
+        enum Decision {
+            Apply,
+            Skip,      // dry-run / user declined / nothing to do
+            PlanOnly,  // dry-run
+        }
+        let decision = if opts.dry_run {
+            Decision::PlanOnly
+        } else if opts.accept_patches {
+            Decision::Apply
+        } else {
+            // Pre-plan via dry-run: if nothing would change, skip the prompt.
+            let needs_work = patch_plan.iter().try_fold(false, |acc, (_, pkg)| {
+                if acc {
+                    return Ok::<bool, anyhow::Error>(true);
+                }
+                let report = patches::apply_patches(
+                    &project_dir,
+                    &pkg.patches,
+                    &prior_ledger(&pkg.name),
+                    PatchOptions { dry_run: true },
+                )?;
+                Ok(!report.nothing_to_do())
+            })?;
+            if !needs_work {
+                println!("  {} Patches already applied; nothing to do", "✓".green());
+                Decision::Skip
+            } else {
+                let names: Vec<_> = patch_plan.iter().map(|(_, p)| p.name.as_str()).collect();
+                if patches::prompt_user(&names.join(", "), &summary)? {
+                    Decision::Apply
+                } else {
+                    println!(
+                        "{} Declined; re-run with `--accept-patches` to apply.",
+                        "·".dimmed()
+                    );
+                    Decision::Skip
+                }
+            }
+        };
+
+        match decision {
+            Decision::Apply => {
+                for (i, pkg) in &patch_plan {
+                    let report = patches::apply_patches(
+                        &project_dir,
+                        &pkg.patches,
+                        &prior_ledger(&pkg.name),
+                        PatchOptions { dry_run: false },
+                    )?;
+                    if !report.refused.is_empty() {
+                        println!();
+                        println!(
+                            "{} {} patch(es) refused:",
+                            "⚠".yellow(),
+                            report.refused.len()
+                        );
+                        for r in &report.refused {
+                            println!("    {} {}: {}", "·".dimmed(), r.file.yellow(), r.reason);
+                        }
+                    }
+                    if !report.applied.is_empty() {
+                        println!(
+                            "  {} Recorded {} patch ledger entry(ies) for {}",
+                            "✓".green(),
+                            report.applied.len(),
+                            pkg.name.yellow()
+                        );
+                    }
+                    locked_packages[*i].applied_patches = report.applied;
+                }
+            }
+            Decision::PlanOnly => {
+                println!();
+                println!(
+                    "{} Dry run — no files modified ({} patches would be applied)",
+                    "·".dimmed(),
+                    patch_plan.iter().map(|(_, p)| p.patches.len()).sum::<usize>()
+                );
+            }
+            Decision::Skip => { /* already printed its own reason above */ }
+        }
+    }
+
     // Generate/update lockfile
-    let lock_path = project_dir.join("nockapp.lock");
     let lockfile = NockAppLock {
         package: locked_packages,
     };
 
-    lockfile.save(&lock_path)?;
-    println!("  Updated nockapp.lock");
+    if !opts.dry_run {
+        lockfile.save(&lock_path)?;
+        println!("  Updated nockapp.lock");
+    }
 
     Ok(())
 }

--- a/crates/nockup/src/commands/package/install.rs
+++ b/crates/nockup/src/commands/package/install.rs
@@ -233,7 +233,7 @@ pub async fn run(opts: InstallOptions) -> Result<()> {
         #[derive(PartialEq)]
         enum Decision {
             Apply,
-            Skip,      // dry-run / user declined / nothing to do
+            Skip,      // user declined, or every patch is already in shape
             PlanOnly,  // dry-run
         }
         let decision = if opts.dry_run {

--- a/crates/nockup/src/commands/package/update.rs
+++ b/crates/nockup/src/commands/package/update.rs
@@ -185,7 +185,10 @@ pub async fn run() -> Result<()> {
     println!();
 
     // Run package install to actually install the updates
-    crate::commands::package::install::run().await?;
+    crate::commands::package::install::run(
+        crate::commands::package::install::InstallOptions::default(),
+    )
+    .await?;
 
     println!();
     println!("{} Updates applied successfully!", "✓".green());

--- a/crates/nockup/src/commands/patches.rs
+++ b/crates/nockup/src/commands/patches.rs
@@ -1,0 +1,96 @@
+//! `nockup patches …` — inspect and release the applied-patches ledger.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::cli::PatchesCommand;
+use crate::manifest::{HoonPackage, NockAppLock};
+
+pub async fn run(cmd: PatchesCommand) -> Result<()> {
+    match cmd {
+        PatchesCommand::Eject { package } => eject(package).await,
+        PatchesCommand::List => list().await,
+    }
+}
+
+/// Release a package's claim on the files it previously patched. Files
+/// on disk stay as-they-are; a later install will re-prompt before
+/// touching them.
+async fn eject(package: String) -> Result<()> {
+    let lock_path = lock_path()?;
+    let mut lockfile = NockAppLock::load(&lock_path)?;
+
+    let mut ejected = 0usize;
+    for entry in lockfile.package.iter_mut() {
+        if entry.name == package {
+            ejected += entry.applied_patches.len();
+            entry.applied_patches.clear();
+        }
+    }
+
+    if ejected == 0 {
+        println!(
+            "{} {} had no applied-patches entries",
+            "·".dimmed(),
+            package.yellow()
+        );
+        return Ok(());
+    }
+
+    lockfile.save(&lock_path)?;
+    println!(
+        "{} Ejected {} patch ledger entry(ies) for {}",
+        "✓".green(),
+        ejected,
+        package.yellow()
+    );
+    Ok(())
+}
+
+async fn list() -> Result<()> {
+    let lockfile = NockAppLock::load(&lock_path()?)?;
+    let mut any = false;
+    for entry in &lockfile.package {
+        if entry.applied_patches.is_empty() {
+            continue;
+        }
+        any = true;
+        println!("{}", entry.name.yellow());
+        for applied in &entry.applied_patches {
+            println!(
+                "  [{}] {}  {}",
+                applied.index + 1,
+                applied.file,
+                format!("({}…)", &applied.content_hash[..12]).dimmed()
+            );
+        }
+    }
+    if !any {
+        println!("  {} No applied patches recorded", "·".dimmed());
+    }
+    Ok(())
+}
+
+/// The install command computes the project dir as `<cwd>/<package-name>`;
+/// mirror that here by reading the consumer's `nockapp.toml`.
+fn lock_path() -> Result<PathBuf> {
+    let cwd = env::current_dir()?;
+    Ok(project_dir(&cwd)?.join("nockapp.lock"))
+}
+
+fn project_dir(cwd: &Path) -> Result<PathBuf> {
+    let manifest_path = cwd.join("nockapp.toml");
+    let pkg = HoonPackage::load(&manifest_path)?
+        .ok_or_else(|| anyhow::anyhow!("No nockapp.toml found in {}", cwd.display()))?;
+    let dir = cwd.join(&pkg.package.name);
+    if !dir.exists() {
+        anyhow::bail!(
+            "Project directory {} not found — run `nockup package install` first",
+            dir.display()
+        );
+    }
+    Ok(dir)
+}

--- a/crates/nockup/src/lib.rs
+++ b/crates/nockup/src/lib.rs
@@ -4,5 +4,6 @@ pub mod commands;
 pub mod git_fetcher;
 pub mod lib_manager;
 pub mod manifest;
+pub mod patches;
 pub mod resolver;
 pub mod version;

--- a/crates/nockup/src/main.rs
+++ b/crates/nockup/src/main.rs
@@ -15,6 +15,7 @@ async fn main() {
         Some(Commands::Package(cmd)) => commands::package::run(cmd).await,
         Some(Commands::Cache(cmd)) => commands::cache::run(cmd).await,
         Some(Commands::Channel(cmd)) => commands::channel::run(cmd).await,
+        Some(Commands::Patches(cmd)) => commands::patches::run(cmd).await,
 
         // Legacy flat commands (backward compatible)
         Some(Commands::Build { project }) => {
@@ -34,7 +35,12 @@ async fn main() {
                 "{}",
                 "warning: `nockup install` is now `nockup update`".yellow()
             );
-            commands::package::run(PackageCommand::Install).await
+            commands::package::run(PackageCommand::Install {
+                accept_patches: false,
+                dry_run: false,
+                show_patches: false,
+            })
+            .await
         }
         Some(Commands::Run { project, args }) => {
             commands::build::run(ProjectCommand::Run {

--- a/crates/nockup/src/manifest.rs
+++ b/crates/nockup/src/manifest.rs
@@ -10,6 +10,8 @@ pub struct HoonPackage {
     pub package: PackageMeta,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<BTreeMap<String, DependencySpec>>,
+    #[serde(default, rename = "patches", skip_serializing_if = "Vec::is_empty")]
+    pub patches: Vec<PackagePatch>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -86,6 +88,44 @@ pub enum DependencySpec {
     },
 }
 
+/// A post-install patch a package asks nockup to apply to the consumer
+/// project after symlinking. See `crate::patches` for the engine.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PackagePatch {
+    pub file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(flatten)]
+    pub op: PatchOp,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum PatchOp {
+    Overwrite {
+        content: String,
+    },
+    ReplacePattern {
+        pattern: String,
+        replacement: String,
+        #[serde(default = "default_true")]
+        once: bool,
+    },
+    EnsureDependency {
+        table: String,
+        name: String,
+        value: toml::Value,
+    },
+    EnsurePatch {
+        registry: String,
+        entries: BTreeMap<String, toml::Value>,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
 // nockapp.lock format – always exact commit hashes
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NockAppLock {
@@ -98,6 +138,18 @@ pub struct LockedPackage {
     // k414", "commit:abc123", "^1.0", etc.
     pub version: String,
     pub source: LockSource,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applied_patches: Vec<AppliedPatch>,
+}
+
+/// One entry per patch the install engine actually wrote (or re-confirmed
+/// as already in shape). The hash lets a later install detect that the
+/// user has since hand-edited the file.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AppliedPatch {
+    pub index: usize,
+    pub file: String,
+    pub content_hash: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/nockup/src/manifest.rs
+++ b/crates/nockup/src/manifest.rs
@@ -10,7 +10,7 @@ pub struct HoonPackage {
     pub package: PackageMeta,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<BTreeMap<String, DependencySpec>>,
-    #[serde(default, rename = "patches", skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub patches: Vec<PackagePatch>,
 }
 

--- a/crates/nockup/src/patches.rs
+++ b/crates/nockup/src/patches.rs
@@ -1,0 +1,401 @@
+//! Post-install patch engine.
+//!
+//! A package can ship a `[[patches]]` array in its `hoon.toml` asking
+//! nockup to reshape specific consumer files after symlinking is done.
+//! Four declarative ops — no shell hooks, no code execution:
+//!
+//! | Op                  | Use case                                            |
+//! |---------------------|-----------------------------------------------------|
+//! | `overwrite`         | replace a scaffold file wholesale                   |
+//! | `replace_pattern`   | swap a scaffold idiom for the package's shape       |
+//! | `ensure_dependency` | insert/preserve a `[<table>].<name>` entry          |
+//! | `ensure_patch`      | merge into `[patch."<registry>"]` without clobber   |
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use regex::Regex;
+use toml_edit::{value as te_value, DocumentMut, Item, Table};
+
+use crate::manifest::{AppliedPatch, PackagePatch, PatchOp};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PatchOptions {
+    /// Plan without writing. Caller still gets a `PatchReport` so it can
+    /// decide what to say on the command line.
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct PatchReport {
+    /// Entries that were (or would be) written to the lockfile ledger.
+    pub applied: Vec<AppliedPatch>,
+    /// Count of `applied` entries that were no-ops (file already in shape).
+    pub skipped_noop: usize,
+    pub refused: Vec<PatchRefusal>,
+}
+
+impl PatchReport {
+    /// True when every patch was a no-op and nothing was refused — i.e.
+    /// the project is already in the shape the package wants.
+    pub fn nothing_to_do(&self) -> bool {
+        self.refused.is_empty() && self.applied.len() == self.skipped_noop
+    }
+}
+
+#[derive(Debug)]
+pub struct PatchRefusal {
+    pub file: String,
+    pub reason: String,
+}
+
+/// Render the summary that both the prompt and `--show-patches` print.
+pub fn summarize(project_dir: &Path, package: &str, patches: &[PackagePatch]) -> String {
+    let mut out = format!(
+        "  {} {} patches from {}:\n",
+        "»".cyan(),
+        patches.len(),
+        package.yellow()
+    );
+    for (idx, patch) in patches.iter().enumerate() {
+        let exists = project_dir.join(&patch.file).exists();
+        let op_label = match &patch.op {
+            PatchOp::Overwrite { .. } if exists => "overwrite".red(),
+            PatchOp::Overwrite { .. } => "create".green(),
+            PatchOp::ReplacePattern { .. } => "replace-pattern".yellow(),
+            PatchOp::EnsureDependency { .. } => "ensure-dependency".cyan(),
+            PatchOp::EnsurePatch { .. } => "ensure-patch".cyan(),
+        };
+        out.push_str(&format!(
+            "    [{}] {:<18} {}\n",
+            idx + 1,
+            op_label,
+            patch.file
+        ));
+        if let Some(desc) = &patch.description {
+            out.push_str(&format!("        {}\n", desc.dimmed()));
+        }
+    }
+    out
+}
+
+pub fn prompt_user(package: &str, summary: &str) -> Result<bool> {
+    eprintln!(
+        "{} Package {} wants to apply {} to your project.",
+        "!".yellow(),
+        package.yellow(),
+        "post-install patches".bold()
+    );
+    eprintln!("{}", summary);
+    eprintln!("  Patches are declarative (no code execution). Apply now? [y/N] ");
+    io::stderr().flush().ok();
+    let mut buf = String::new();
+    io::stdin().read_line(&mut buf)?;
+    Ok(matches!(buf.trim(), "y" | "Y" | "yes" | "YES"))
+}
+
+/// Apply a package's patches against `project_dir`. Caller runs the
+/// confirmation prompt and persists the returned ledger entries.
+pub fn apply_patches(
+    project_dir: &Path,
+    patches: &[PackagePatch],
+    prior_ledger: &[AppliedPatch],
+    opts: PatchOptions,
+) -> Result<PatchReport> {
+    let mut report = PatchReport::default();
+    for (idx, patch) in patches.iter().enumerate() {
+        let prior = prior_ledger.iter().find(|e| e.index == idx);
+        let file_path = project_dir.join(&patch.file);
+        match apply_one(&file_path, idx, patch, prior, opts) {
+            Ok(ApplyOutcome::Applied(entry)) => report.applied.push(entry),
+            Ok(ApplyOutcome::Noop(entry)) => {
+                report.applied.push(entry);
+                report.skipped_noop += 1;
+            }
+            Ok(ApplyOutcome::Refused { reason }) => report.refused.push(PatchRefusal {
+                file: patch.file.clone(),
+                reason,
+            }),
+            Err(e) => report.refused.push(PatchRefusal {
+                file: patch.file.clone(),
+                reason: format!("{e:#}"),
+            }),
+        }
+    }
+    Ok(report)
+}
+
+// --- internals -------------------------------------------------------------
+
+enum ApplyOutcome {
+    Applied(AppliedPatch),
+    Noop(AppliedPatch),
+    Refused { reason: String },
+}
+
+fn apply_one(
+    file_path: &Path,
+    idx: usize,
+    patch: &PackagePatch,
+    prior: Option<&AppliedPatch>,
+    opts: PatchOptions,
+) -> Result<ApplyOutcome> {
+    match &patch.op {
+        PatchOp::Overwrite { content } => overwrite_op(file_path, idx, patch, content, prior, opts),
+        PatchOp::ReplacePattern {
+            pattern,
+            replacement,
+            once,
+        } => replace_pattern_op(file_path, idx, patch, pattern, replacement, *once, opts),
+        PatchOp::EnsureDependency { table, name, value } => {
+            ensure_toml_entry(file_path, idx, patch, &[table.as_str()], name, value, opts)
+        }
+        PatchOp::EnsurePatch { registry, entries } => {
+            // One declared patch, but multiple entries. Fold their outcomes
+            // into a single report entry so the ledger has a 1:1 mapping
+            // with the `[[patches]]` array.
+            let mut any_written = false;
+            let mut last: Option<AppliedPatch> = None;
+            for (name, value) in entries {
+                match ensure_toml_entry(
+                    file_path,
+                    idx,
+                    patch,
+                    &["patch", registry.as_str()],
+                    name,
+                    value,
+                    opts,
+                )? {
+                    ApplyOutcome::Applied(entry) => {
+                        any_written = true;
+                        last = Some(entry);
+                    }
+                    ApplyOutcome::Noop(entry) => last = Some(entry),
+                    refused @ ApplyOutcome::Refused { .. } => return Ok(refused),
+                }
+            }
+            let entry = last.unwrap_or_else(|| AppliedPatch {
+                index: idx,
+                file: patch.file.clone(),
+                content_hash: blake3_file(file_path).unwrap_or_default(),
+            });
+            Ok(if any_written {
+                ApplyOutcome::Applied(entry)
+            } else {
+                ApplyOutcome::Noop(entry)
+            })
+        }
+    }
+}
+
+fn overwrite_op(
+    file_path: &Path,
+    idx: usize,
+    patch: &PackagePatch,
+    content: &str,
+    prior: Option<&AppliedPatch>,
+    opts: PatchOptions,
+) -> Result<ApplyOutcome> {
+    if file_path.exists() {
+        let current = fs::read_to_string(file_path)?;
+        if current == content {
+            return Ok(ApplyOutcome::Noop(ledger_entry(idx, patch, &current)));
+        }
+        // Refuse if the user has edited a previously-patched file.
+        if let Some(entry) = prior {
+            let cur_hash = blake3_bytes(current.as_bytes());
+            if cur_hash != entry.content_hash {
+                return Ok(ApplyOutcome::Refused {
+                    reason: format!(
+                        "file was edited since last install (hash {} != ledger {}); \
+                         resolve manually or run `nockup patches eject`",
+                        &cur_hash[..12],
+                        &entry.content_hash[..12],
+                    ),
+                });
+            }
+        }
+    }
+    if !opts.dry_run {
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+        fs::write(file_path, content)
+            .with_context(|| format!("Failed to write {}", file_path.display()))?;
+    }
+    Ok(ApplyOutcome::Applied(ledger_entry(idx, patch, content)))
+}
+
+fn replace_pattern_op(
+    file_path: &Path,
+    idx: usize,
+    patch: &PackagePatch,
+    pattern: &str,
+    replacement: &str,
+    once: bool,
+    opts: PatchOptions,
+) -> Result<ApplyOutcome> {
+    if !file_path.exists() {
+        return Ok(ApplyOutcome::Refused {
+            reason: format!("target {} does not exist", patch.file),
+        });
+    }
+    let before = fs::read_to_string(file_path)?;
+    let re = Regex::new(pattern).with_context(|| format!("invalid regex `{pattern}`"))?;
+    if !re.is_match(&before) {
+        // Pattern gone and replacement present → already applied.
+        if before.contains(replacement) {
+            return Ok(ApplyOutcome::Noop(ledger_entry(idx, patch, &before)));
+        }
+        return Ok(ApplyOutcome::Refused {
+            reason: format!(
+                "pattern `{pattern}` does not match in {} and replacement is absent; \
+                 consumer file is in an unknown state",
+                patch.file
+            ),
+        });
+    }
+    let after = if once {
+        re.replacen(&before, 1, replacement).into_owned()
+    } else {
+        re.replace_all(&before, replacement).into_owned()
+    };
+    if !opts.dry_run {
+        fs::write(file_path, &after)?;
+    }
+    Ok(ApplyOutcome::Applied(ledger_entry(idx, patch, &after)))
+}
+
+fn ensure_toml_entry(
+    file_path: &Path,
+    idx: usize,
+    patch: &PackagePatch,
+    table_path: &[&str],
+    name: &str,
+    value: &toml::Value,
+    opts: PatchOptions,
+) -> Result<ApplyOutcome> {
+    debug_assert!(!table_path.is_empty(), "table_path must be non-empty");
+
+    let mut doc = if file_path.exists() {
+        read_toml_doc(file_path)?
+    } else {
+        DocumentMut::new()
+    };
+
+    // Walk / create the table path. Non-leaf segments stay implicit so
+    // we don't render an empty `[parent]` above `[parent.child]`.
+    let leaf = table_path.len() - 1;
+    let mut cursor: &mut Item = doc.as_item_mut();
+    for (i, segment) in table_path.iter().enumerate() {
+        let tbl = cursor
+            .as_table_mut()
+            .ok_or_else(|| anyhow::anyhow!("expected `{segment}` to be a table in {}", patch.file))?;
+        if !tbl.contains_key(segment) {
+            let mut new_table = Table::new();
+            new_table.set_implicit(i != leaf);
+            tbl.insert(segment, Item::Table(new_table));
+        }
+        cursor = tbl.get_mut(segment).expect("just inserted");
+    }
+    let tbl = cursor
+        .as_table_mut()
+        .expect("walk terminates on a Table we either found or created");
+
+    let new_item = te_value(toml_value_to_edit(value));
+
+    if let Some(existing) = tbl.get(name) {
+        if items_equal(existing, &new_item) {
+            let on_disk = blake3_file(file_path).unwrap_or_default();
+            return Ok(ApplyOutcome::Noop(AppliedPatch {
+                index: idx,
+                file: patch.file.clone(),
+                content_hash: on_disk,
+            }));
+        }
+        return Ok(ApplyOutcome::Refused {
+            reason: format!(
+                "`[{}].{}` already has a different value; leaving user's edit in place",
+                table_path.join("."),
+                name
+            ),
+        });
+    }
+
+    tbl.insert(name, new_item);
+    let new_text = doc.to_string();
+    if !opts.dry_run {
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(file_path, &new_text)?;
+    }
+    Ok(ApplyOutcome::Applied(AppliedPatch {
+        index: idx,
+        file: patch.file.clone(),
+        content_hash: blake3_bytes(new_text.as_bytes()),
+    }))
+}
+
+fn ledger_entry(idx: usize, patch: &PackagePatch, content: &str) -> AppliedPatch {
+    AppliedPatch {
+        index: idx,
+        file: patch.file.clone(),
+        content_hash: blake3_bytes(content.as_bytes()),
+    }
+}
+
+fn read_toml_doc(path: &Path) -> Result<DocumentMut> {
+    fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?
+        .parse::<DocumentMut>()
+        .with_context(|| format!("Failed to parse {} as TOML", path.display()))
+}
+
+fn items_equal(a: &Item, b: &Item) -> bool {
+    a.to_string().trim() == b.to_string().trim()
+}
+
+/// Convert a `toml::Value` into a `toml_edit::Value` by recursing over
+/// variants. A string round-trip doesn't work: `toml::to_string` on a
+/// `Value::Table` emits bare keys (`k = v\n`), not inline-table syntax
+/// (`{ k = v }`), so naive wrapping produces invalid TOML.
+fn toml_value_to_edit(v: &toml::Value) -> toml_edit::Value {
+    use toml_edit::{Array, InlineTable, Value as TeValue};
+    match v {
+        toml::Value::String(s) => TeValue::from(s.as_str()),
+        toml::Value::Integer(i) => TeValue::from(*i),
+        toml::Value::Float(f) => TeValue::from(*f),
+        toml::Value::Boolean(b) => TeValue::from(*b),
+        toml::Value::Datetime(dt) => TeValue::from(dt.to_string()),
+        toml::Value::Array(arr) => {
+            let mut out = Array::new();
+            for item in arr {
+                out.push(toml_value_to_edit(item));
+            }
+            TeValue::Array(out)
+        }
+        toml::Value::Table(tbl) => {
+            let mut out = InlineTable::new();
+            for (k, v) in tbl {
+                out.insert(k, toml_value_to_edit(v));
+            }
+            TeValue::InlineTable(out)
+        }
+    }
+}
+
+fn blake3_file(path: &Path) -> Result<String> {
+    Ok(blake3_bytes(&fs::read(path)?))
+}
+
+fn blake3_bytes(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/nockup/src/patches/tests.rs
+++ b/crates/nockup/src/patches/tests.rs
@@ -1,0 +1,298 @@
+use std::collections::BTreeMap;
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::manifest::{PackagePatch, PatchOp};
+
+/// Build a fresh empty project dir for a test.
+fn scratch() -> TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn patch_overwrite(file: &str, body: &str) -> PackagePatch {
+    PackagePatch {
+        file: file.into(),
+        description: None,
+        op: PatchOp::Overwrite {
+            content: body.into(),
+        },
+    }
+}
+
+fn patch_replace(file: &str, pattern: &str, replacement: &str) -> PackagePatch {
+    PackagePatch {
+        file: file.into(),
+        description: None,
+        op: PatchOp::ReplacePattern {
+            pattern: pattern.into(),
+            replacement: replacement.into(),
+            once: true,
+        },
+    }
+}
+
+fn patch_ensure_dep(file: &str, name: &str, value: toml::Value) -> PackagePatch {
+    PackagePatch {
+        file: file.into(),
+        description: None,
+        op: PatchOp::EnsureDependency {
+            table: "dependencies".into(),
+            name: name.into(),
+            value,
+        },
+    }
+}
+
+fn patch_ensure_patch(
+    file: &str,
+    registry: &str,
+    entries: BTreeMap<String, toml::Value>,
+) -> PackagePatch {
+    PackagePatch {
+        file: file.into(),
+        description: None,
+        op: PatchOp::EnsurePatch {
+            registry: registry.into(),
+            entries,
+        },
+    }
+}
+
+fn opts() -> PatchOptions {
+    PatchOptions { dry_run: false }
+}
+
+// --- overwrite -------------------------------------------------------------
+
+#[test]
+fn overwrite_applies_to_fresh_file() {
+    let dir = scratch();
+    let patches = vec![patch_overwrite("build.rs", "fn main() {}\n")];
+    let report = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    let body = fs::read_to_string(dir.path().join("build.rs")).unwrap();
+    assert_eq!(body, "fn main() {}\n");
+    assert_eq!(report.applied.len(), 1);
+    assert!(report.refused.is_empty());
+}
+
+#[test]
+fn overwrite_is_idempotent() {
+    let dir = scratch();
+    let patches = vec![patch_overwrite("build.rs", "fn main() {}\n")];
+    let first = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    // Re-running with the prior ledger should no-op — file already matches.
+    let second = apply_patches(dir.path(), &patches, &first.applied, opts()).unwrap();
+    assert_eq!(second.skipped_noop, 1);
+    assert!(second.refused.is_empty());
+}
+
+#[test]
+fn overwrite_refuses_user_edited_file() {
+    let dir = scratch();
+    let patches = vec![patch_overwrite("build.rs", "fn main() {}\n")];
+    let first = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    // User edits the patched file out-of-band.
+    fs::write(dir.path().join("build.rs"), "// user's own version\n").unwrap();
+    let second = apply_patches(dir.path(), &patches, &first.applied, opts()).unwrap();
+    assert_eq!(second.refused.len(), 1);
+    assert!(second.refused[0].reason.contains("edited since last install"));
+}
+
+// --- replace_pattern -------------------------------------------------------
+
+#[test]
+fn replace_pattern_once_replaces_first_match_only() {
+    let dir = scratch();
+    fs::write(dir.path().join("main.rs"), "Some(cli) Some(cli)").unwrap();
+    let patches = vec![patch_replace(
+        "main.rs",
+        r#"Some\(cli\)"#,
+        "cli",
+    )];
+    apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    let body = fs::read_to_string(dir.path().join("main.rs")).unwrap();
+    assert_eq!(body, "cli Some(cli)");
+}
+
+#[test]
+fn replace_pattern_idempotent_after_first_apply() {
+    let dir = scratch();
+    fs::write(dir.path().join("main.rs"), "Some(cli)").unwrap();
+    let patches = vec![patch_replace(
+        "main.rs",
+        r#"Some\(cli\)"#,
+        "cli",
+    )];
+    let first = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    let second = apply_patches(dir.path(), &patches, &first.applied, opts()).unwrap();
+    assert_eq!(second.skipped_noop, 1);
+    assert!(second.refused.is_empty());
+}
+
+#[test]
+fn replace_pattern_refuses_on_missing_pattern_and_replacement() {
+    let dir = scratch();
+    // Neither pattern nor replacement present → consumer file is in an
+    // unknown state; engine refuses rather than guessing.
+    fs::write(dir.path().join("main.rs"), "something unrelated").unwrap();
+    let patches = vec![patch_replace(
+        "main.rs",
+        r#"Some\(cli\)"#,
+        "cli",
+    )];
+    let report = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    assert_eq!(report.refused.len(), 1);
+}
+
+// --- ensure_dependency ----------------------------------------------------
+
+#[test]
+fn ensure_dependency_inserts_into_fresh_file() {
+    let dir = scratch();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    let patches = vec![patch_ensure_dep(
+        "Cargo.toml",
+        "vesl-core",
+        toml::Value::String("1.0".into()),
+    )];
+    apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    let body = fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(body.contains("vesl-core = \"1.0\""), "body was: {}", body);
+}
+
+#[test]
+fn ensure_dependency_no_op_when_identical() {
+    let dir = scratch();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\n\n[dependencies]\nvesl-core = \"1.0\"\n",
+    )
+    .unwrap();
+    let patches = vec![patch_ensure_dep(
+        "Cargo.toml",
+        "vesl-core",
+        toml::Value::String("1.0".into()),
+    )];
+    let report = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    assert_eq!(report.skipped_noop, 1);
+    assert!(report.refused.is_empty());
+}
+
+#[test]
+fn ensure_dependency_preserves_user_value_on_conflict() {
+    let dir = scratch();
+    let before = "[package]\nname = \"x\"\n\n[dependencies]\nvesl-core = \"9.9\"\n";
+    fs::write(dir.path().join("Cargo.toml"), before).unwrap();
+    let patches = vec![patch_ensure_dep(
+        "Cargo.toml",
+        "vesl-core",
+        toml::Value::String("1.0".into()),
+    )];
+    let report = apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    assert_eq!(report.refused.len(), 1);
+    let body = fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert_eq!(body, before, "user's version must be preserved");
+}
+
+// --- ensure_patch ---------------------------------------------------------
+
+#[test]
+fn ensure_dependency_inline_table_round_trips_values() {
+    // Regression guard: an earlier draft of `toml_value_to_edit` emitted
+    // empty RHS when handed an inline table, so `vesl-core = { path = .. }`
+    // rendered as `vesl-core = ""` in the consumer project.
+    let dir = scratch();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    let mut inline = toml::value::Table::new();
+    inline.insert(
+        "path".into(),
+        toml::Value::String("../../vesl/crates/vesl-core".into()),
+    );
+    let patches = vec![patch_ensure_dep(
+        "Cargo.toml",
+        "vesl-core",
+        toml::Value::Table(inline),
+    )];
+    apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    let body = fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(
+        body.contains(r#"vesl-core = { path = "../../vesl/crates/vesl-core" }"#),
+        "inline table should render with its contents, got:\n{}",
+        body
+    );
+}
+
+#[test]
+fn ensure_patch_merges_into_registry_table() {
+    let dir = scratch();
+    fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+    let mut entries = BTreeMap::new();
+    entries.insert("nockapp".into(), {
+        let mut inline = toml::value::Table::new();
+        inline.insert(
+            "path".into(),
+            toml::Value::String("../nockchain/crates/nockapp".into()),
+        );
+        toml::Value::Table(inline)
+    });
+    let patches = vec![patch_ensure_patch(
+        "Cargo.toml",
+        "https://github.com/nockchain/nockchain.git",
+        entries,
+    )];
+    apply_patches(dir.path(), &patches, &[], opts()).unwrap();
+    let body = fs::read_to_string(dir.path().join("Cargo.toml")).unwrap();
+    assert!(body.contains("[patch.\"https://github.com/nockchain/nockchain.git\"]"));
+    // Inline-table value must round-trip — not collapse to `nockapp = ""`.
+    assert!(
+        body.contains(r#"nockapp = { path = "../nockchain/crates/nockapp" }"#),
+        "entry should render as a full inline table, got:\n{}",
+        body
+    );
+    // And the parent `[patch]` header must stay implicit (no empty section).
+    assert!(
+        !body.contains("\n[patch]\n"),
+        "parent `[patch]` table should be implicit, got:\n{}",
+        body
+    );
+}
+
+// --- dry run / summary ---------------------------------------------------
+
+#[test]
+fn dry_run_does_not_touch_filesystem() {
+    let dir = scratch();
+    let patches = vec![patch_overwrite("build.rs", "fn main() {}\n")];
+    let report = apply_patches(
+        dir.path(),
+        &patches,
+        &[],
+        PatchOptions { dry_run: true },
+    )
+    .unwrap();
+    assert_eq!(report.applied.len(), 1);
+    assert!(!dir.path().join("build.rs").exists());
+}
+
+#[test]
+fn summarize_lists_every_patch() {
+    let dir = scratch();
+    let patches = vec![
+        patch_overwrite("build.rs", "x"),
+        patch_replace("main.rs", "a", "b"),
+    ];
+    let text = summarize(dir.path(), "zkvesl/vesl-graft", &patches);
+    assert!(text.contains("zkvesl/vesl-graft"));
+    assert!(text.contains("build.rs"));
+    assert!(text.contains("main.rs"));
+}

--- a/crates/nockup/src/resolver/engine.rs
+++ b/crates/nockup/src/resolver/engine.rs
@@ -6,9 +6,19 @@ use colored::Colorize;
 
 use crate::cache::PackageCache;
 use crate::git_fetcher::{GitFetcher, GitSpec};
-use crate::manifest::{DependencySpec, HoonPackage};
+use crate::manifest::{DependencySpec, HoonPackage, PackagePatch};
 use crate::resolver::types::{ResolvedGraph, ResolvedPackage};
 use crate::resolver::{registry, VersionSpec};
+
+fn load_patches_from_dir(dir: &Path) -> Result<Vec<PackagePatch>> {
+    let manifest_path = dir.join("hoon.toml");
+    if !manifest_path.exists() {
+        return Ok(Vec::new());
+    }
+    Ok(HoonPackage::load(&manifest_path)?
+        .map(|p| p.patches)
+        .unwrap_or_default())
+}
 
 /// Main dependency resolver
 pub struct Resolver {
@@ -148,9 +158,8 @@ impl Resolver {
         // Validate all requested source files exist
         let source_files = self.validate_source_files(&source_dir, spec)?;
 
-        // Check for transitive dependencies (look for hoon.toml in fetched repo)
-        let transitive_deps = self
-            .load_transitive_deps(repo_path.as_path(), &git_spec)
+        let (transitive_deps, patches) = self
+            .load_package_metadata(repo_path.as_path(), &git_spec)
             .await?;
 
         if !transitive_deps.is_empty() {
@@ -158,6 +167,14 @@ impl Resolver {
                 "    {} Found {} transitive dependencies",
                 "→".cyan(),
                 transitive_deps.len()
+            );
+        }
+
+        if !patches.is_empty() {
+            println!(
+                "    {} Package declares {} post-install patch(es)",
+                "→".cyan(),
+                patches.len()
             );
         }
 
@@ -194,6 +211,7 @@ impl Resolver {
                 Some(source_files)
             },
             dependencies: transitive_deps,
+            patches,
         })
     }
 
@@ -218,6 +236,11 @@ impl Resolver {
                 _ => None,
             };
 
+            // The cache stores the *contents of the source path*, so the
+            // package's own hoon.toml (if any) lives at the cache root.
+            let cached_path = self.cache.package_path(name, &version_str);
+            let patches = load_patches_from_dir(&cached_path).unwrap_or_default();
+
             return Ok(Some(ResolvedPackage {
                 name: name.to_string(),
                 version_spec,
@@ -227,6 +250,7 @@ impl Resolver {
                 install_path: git_spec.install_path,
                 source_files,
                 dependencies: HashMap::new(), // TODO: Store in cache metadata
+                patches,
             }));
         }
 
@@ -337,13 +361,13 @@ impl Resolver {
         }
     }
 
-    /// Load transitive dependencies from a fetched package
-    async fn load_transitive_deps(
+    /// Read the package's `hoon.toml` to pick up transitive deps and any
+    /// `[[patches]]` block in one pass.
+    async fn load_package_metadata(
         &self,
         repo_path: &Path,
         git_spec: &GitSpec,
-    ) -> Result<HashMap<String, DependencySpec>> {
-        // Check for hoon.toml in the fetched repo
+    ) -> Result<(HashMap<String, DependencySpec>, Vec<PackagePatch>)> {
         let manifest_path = if let Some(ref subdir) = git_spec.path {
             repo_path.join(subdir).join("hoon.toml")
         } else {
@@ -351,14 +375,15 @@ impl Resolver {
         };
 
         if !manifest_path.exists() {
-            // No transitive dependencies
-            return Ok(HashMap::new());
+            return Ok((HashMap::new(), Vec::new()));
         }
 
-        // Load and parse manifest
         match HoonPackage::load(&manifest_path)? {
-            Some(pkg) => Ok(pkg.dependencies.unwrap_or_default().into_iter().collect()),
-            None => Ok(HashMap::new()),
+            Some(pkg) => Ok((
+                pkg.dependencies.unwrap_or_default().into_iter().collect(),
+                pkg.patches,
+            )),
+            None => Ok((HashMap::new(), Vec::new())),
         }
     }
 

--- a/crates/nockup/src/resolver/types.rs
+++ b/crates/nockup/src/resolver/types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::manifest::DependencySpec;
+use crate::manifest::{DependencySpec, PackagePatch};
 use crate::resolver::VersionSpec;
 
 /// A resolved package with exact commit and dependencies
@@ -14,6 +14,10 @@ pub struct ResolvedPackage {
     pub install_path: Option<String>, // Subdir to install to (e.g., "sys")
     pub source_files: Option<Vec<String>>, // Specific files to extract (if any)
     pub dependencies: HashMap<String, DependencySpec>, // Transitive deps
+    /// Post-install patches the package wants applied to the consumer
+    /// project. Populated from the package's own `hoon.toml` / `nockapp.toml`
+    /// at resolve time; the install step hands these to the patch engine.
+    pub patches: Vec<PackagePatch>,
 }
 
 /// A resolved dependency graph


### PR DESCRIPTION
## What this changes

A package can ship a `[[patches]]` array in its `hoon.toml`. After
`nockup package install` finishes its Hoon symlinks, the new engine
walks that array and reshapes specific files in the consumer project —
with a y/N confirmation and a full summary before anything is written.

Four declarative ops, no code execution:

| op | use |
|---|---|
| `overwrite` | replace a file wholesale |
| `replace_pattern` | regex substitution, `once = true` by default |
| `ensure_dependency` | insert/preserve `[<table>].<name> = <value>` (TOML-aware via `toml_edit`) |
| `ensure_patch` | merge into `[patch."<registry>"]` |

All idempotent. All refuse rather than overwrite when the consumer's
file has diverged from what the ledger expects — user edits win.

## Why

Today a package's only way to influence a consumer project is symlinks
into `hoon/lib/` and `hoon/sur/`. Anything Rust-side — a Cargo dep, a
`[patch]` block, a build.rs shape — has to live in the README and rely
on the user to apply by hand.

The concrete thing that pushed this: the `basic` scaffold currently
leaves three small gaps for packages to paper over — an empty Cargo
`rev`, a `build.rs` that shells `hoonc --output $OUT_DIR/…` (the out
path most packages actually want is project root), and `src/main.rs`
wrapping `cli` in `Some(…)` for a signature that takes `Cli`. Any
package installing into that scaffold has to document the same three
fixups. With `[[patches]]` the package declares them once; the user's
first install is a clean build.

It's a general mechanism. Any package needing a Cargo dep, a build-
script rewrite, or a `[patch]` redirect can use the same ops.

## CLI additions

- `nockup package install --accept-patches` — skip the y/N prompt (CI).
- `nockup package install --dry-run` — plan without writing.
- `nockup package install --show-patches` — print the plan.
- `nockup patches list` — show the applied-patches ledger.
- `nockup patches eject <package>` — release a package's claim on its
  patched files; files stay on disk as-they-are, and a later install
  re-prompts before touching them.

## Ledger

`LockedPackage` gains `applied_patches: Vec<AppliedPatch>`, one entry
per patch with a `blake3` of the file after apply. On re-install we
compare the current file hash against the ledger — mismatch means the
user edited by hand, and `overwrite` refuses rather than clobber.

The ledger lives in `nockapp.lock` rather than a side file so it's
version-controlled and rolled-back together with the dep set. Happy
to move to `.nockup/patches.lock` if reviewers prefer that.

## Backwards compatibility

- `HoonPackage.patches` and `LockedPackage.applied_patches` are both
  `#[serde(default, skip_serializing_if = ...)]`. Manifests / lockfiles
  written by older nockup load and round-trip unchanged.
- `PackageCommand::Install` gained fields; the legacy flat dispatch
  fills them with defaults.
- Packages without `[[patches]]` install exactly as before — the patch
  code path is guarded on an empty vec.

## Dependencies

Two new workspace deps:

- `regex = "1.10"` — backs `replace_pattern`.
- `toml_edit = "0.22"` — formatting-preserving `Cargo.toml` edits.

## Testing

`crates/nockup/src/patches/tests.rs` — 13 unit tests covering each op's
apply / idempotence / refuse paths, plus regression guards for two
TOML-rendering bugs caught during the validation below.

End-to-end: ran `nockup project init → package install --accept-patches
→ cargo +nightly check` against a package declaring the three scaffold
fixups above. `cargo check` exits 0 with no manual edits, and re-running
`package install` is a silent no-op (ledger consulted, prompt skipped).

## Test plan

- [ ] `cargo +nightly test -p nockup --lib patches` — 13/13 pass.
- [ ] `cargo +nightly check -p nockup --tests` — clean.
- [ ] Fresh `nockup project init → package install --accept-patches`
      against a package declaring `[[patches]]` → `cargo +nightly
      check` exits 0 with no manual edits.
- [ ] Re-running `package install` is silent (ledger consulted).
- [ ] `nockup patches eject <pkg>` clears the ledger; files stay on
      disk.
- [ ] A package without `[[patches]]` installs exactly as before.