### PR TITLE
feat(nockapp): public NockApp::export_state for live-app snapshot

### DIFF
--- a/crates/nockapp/src/nockapp/mod.rs
+++ b/crates/nockapp/src/nockapp/mod.rs
@@ -9,6 +9,7 @@ pub mod test;
 pub mod wire;
 
 use std::future::Future;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -342,6 +343,27 @@ impl<J: Jammer + Send + 'static> NockApp<J> {
 
     pub async fn export(&self) -> Result<crate::kernel::form::LoadState, NockAppError> {
         Ok(self.kernel.export().await?)
+    }
+
+    /// Export the current kernel state to `path` in [`ExportedState`]
+    /// format. The resulting file can be loaded back into a fresh
+    /// `NockApp` via the boot `Cli`'s `state_jam` field.
+    ///
+    /// Differs from `boot::setup` with `cli.export_state_jam`: that
+    /// path runs at boot and exits after writing. This method exports
+    /// from a live, running app and leaves it intact, so callers can
+    /// snapshot mid-lifecycle without losing the runtime.
+    ///
+    /// [`ExportedState`]: crate::nockapp::export::ExportedState
+    pub async fn export_state(&self, path: &Path) -> Result<(), NockAppError> {
+        let kernel_state = self.kernel.export().await?;
+        let exported_state =
+            crate::nockapp::export::ExportedState::from_loadstate::<J>(kernel_state);
+        let state_bytes = exported_state.encode()?;
+        tokio::fs::write(path, state_bytes)
+            .await
+            .map_err(NockAppError::SaveError)?;
+        Ok(())
     }
 
     pub async fn poke_timeout(


### PR DESCRIPTION
## What this changes

Adds a public `export_state(&self, path)` method on `NockApp<J>` that serializes the current kernel state via the existing `Kernel::export` → `ExportedState::from_loadstate::<J>` → `ExportedState::encode` chain and writes it to disk. The resulting file is identical in format to what `boot::setup` writes when `Cli::export_state_jam` is set — i.e., loadable back through `Cli::state_jam` on a fresh boot. Wire-compatible with the existing import path: no companion patch on the resume side.

```rust
// in crates/nockapp/src/nockapp/mod.rs, on impl<J: Jammer + Send + 'static> NockApp<J>
pub async fn export_state(&self, path: &Path) -> Result<(), NockAppError> {
    let kernel_state = self.kernel.export().await?;
    let exported_state =
        crate::nockapp::export::ExportedState::from_loadstate::<J>(kernel_state);
    let state_bytes = exported_state.encode()?;
    tokio::fs::write(path, state_bytes)
        .await
        .map_err(NockAppError::SaveError)?;
    Ok(())
}
```

## Why

`NockApp::export()` (already on master) returns the in-memory `LoadState`. The boot-time `cli.export_state_jam` path takes that `LoadState`, runs it through `ExportedState::from_loadstate::<J>` + `encode`, and writes the bytes to disk — but it does so inside `boot::setup` and exits after writing (`SetupResult::ExportedState`). That's the right shape for a shutdown-time export, but it consumes the live app.

The concrete consumer that pushed this: a snapshot/resume wrapper crate (`vesl-checkpoint` in the vesl tree) where the contract is

```rust
let snap = vesl_checkpoint::snapshot(&app, dir, &app_hoon).await?;
drop(app);
let resumed = vesl_checkpoint::resume(jam_path, &snap, "name").await?;
```

`snapshot` needs `&self` so the live app keeps running through the write — no consume, no early return. Without a public method on `NockApp`, that crate has to either fork nockapp or duplicate the file-write wrapper internally.

`export_state` is the file-write counterpart to the existing `NockApp::export()`: same composition as `boot.rs::export_kernel_state::<J, _>`, just hung off `NockApp` so live callers can use it without going through `Cli`.

## PMA compatibility

Rebased onto master post-PMA (#38). The `J: Jammer` turbofish on `from_loadstate` matches the PMA-era boot helpers (`export_kernel_state::<J, _>` / `import_kernel_state::<J, _>`), so PMA-backed snapshot files on disk and the kernel-state jam written here remain orthogonal — PMA snapshots are runtime persistence, the state jam is portable export consumable by `--state-jam`. Verified end-to-end: `cargo check -p nockapp` clean on master + this patch.

## Backwards compatibility

Purely additive:

- `NockApp::export_state` is a new method; no existing signature changes.
- The existing `NockApp::export()` (`LoadState`-returning) and the boot-time `export_state_jam` path are untouched.
- `ExportedState`, `Kernel::export`, and `import_kernel_state` are the same types and entry points the new method composes — no format change, no version bump, no new dep.

## Validation

The downstream consumer (`vesl-checkpoint`) lands in the vesl tree with two end-to-end tests that exercise this method:

1. **Structural round-trip** (`vesl-core/crates/vesl-checkpoint/tests/end_to_end.rs`): boot a fixture kernel, call `snapshot()`, verify `state.jam` + `meta.toml` on disk, drop the app, call `resume()`, assert resume completes.

2. **State-equivalence** (`vesl-nockup/tools/graft-inject/tests/checkpoint_lifecycle.rs`): compose a settle-graft kernel, register hull 1 with a known root, snapshot, drop, resume, peek `[%settle-root hull=1 ~]`, assert the stored root equals the pre-snapshot root.

Both pass on the `vesl-core/feature/checkpoint-snapshot-resume` branch. This patch is the upstream prerequisite — without it, the downstream crate can't compile.

## Test plan

- [ ] `cargo test -p nockapp` clean — no regressions in existing nockapp tests; the new method has no test of its own here (it composes already-tested primitives).
- [ ] `cargo build -p nockapp` clean — no new warnings.
- [ ] Downstream `vesl-checkpoint` compiles against this branch with no further patches.
- [ ] Downstream `cargo test -p vesl-checkpoint` end-to-end pass.
- [ ] Downstream `cargo test -p graft-inject --test checkpoint_lifecycle` passes (state-equivalence with a real graft).

## Notes

- Method takes `&Path`, not `&str` or `String` — matches how `boot::setup`'s `data_dir: Option<PathBuf>` and the existing filesystem entry points are typed elsewhere in nockapp.
- Error type: `NockAppError`. `Kernel::export`'s `CrownError` and `ExportedState::encode`'s `bincode::EncodeError` already auto-convert via `#[from]`; the `tokio::fs::write` `io::Error` maps to `NockAppError::SaveError` (which is `#[source]`, not `#[from]`, so the conversion is explicit).
- The crate-private `kernel` field (`pub(crate)`) stays unchanged; `export_state` is the only new public surface. An equivalent alternative — `pub fn kernel(&self) -> &Kernel<...>` letting consumers call `kernel().export()` themselves — leaks more internals; the method-on-NockApp shape is narrower.
