### PR TITLE
feat(nockup): extension hooks for downstream-owned templates and subcommands

### DIFF
--- a/crates/nockup/src/cli.rs
+++ b/crates/nockup/src/cli.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -60,6 +62,12 @@ pub enum Commands {
     /// Test Phase 1 infrastructure (temporary demo command)
     #[command(hide = true)]
     TestPhase1,
+
+    /// External subcommand: `nockup foo bar` execs `nockup-foo bar` from `$PATH`.
+    /// Mirrors cargo's plugin-discovery convention so downstream tools can
+    /// extend the CLI without an upstream PR.
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
 }
 
 #[derive(clap::Subcommand, Debug)]

--- a/crates/nockup/src/commands/build/init.rs
+++ b/crates/nockup/src/commands/build/init.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use colored::Colorize;
 use handlebars::Handlebars;
 
+use crate::git_fetcher::{GitFetcher, GitSpec};
 use crate::manifest::NockAppManifest;
 
 pub async fn run() -> Result<()> {
@@ -44,12 +45,24 @@ pub async fn run() -> Result<()> {
         );
     }
 
-    // Resolve template directory (supports pinned commit)
+    // Resolve template directory. Three sources, in priority order:
+    //   1. `template_git` — fetch from any git URL (incl. `file://`)
+    //   2. `template_commit` pin — channel cache, commit-suffixed
+    //   3. plain channel cache (~/.nockup/templates/<name>/)
     let cache_dir = dirs::home_dir()
         .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
         .join(".nockup/templates");
 
-    let template_src = if let Some(commit) = template_commit {
+    let template_src = if let Some(git_url) = manifest.package.template_git.as_deref() {
+        resolve_git_template(
+            &cache_dir,
+            git_url,
+            template_commit,
+            manifest.package.template_path.as_deref(),
+            template_name,
+        )
+        .await?
+    } else if let Some(commit) = template_commit {
         cache_dir.join(format!("{}-{}", template_name, commit))
     } else {
         cache_dir.join(template_name)
@@ -57,10 +70,15 @@ pub async fn run() -> Result<()> {
 
     if !template_src.exists() {
         anyhow::bail!(
-            "Template '{}' not found in cache at {}.\n\
-             Run `nockup channel update` or check your template-commit hash.",
+            "Template '{}' not found at {}.\n\
+             {}",
             template_name,
-            template_src.display()
+            template_src.display(),
+            if manifest.package.template_git.is_some() {
+                "Verify `template_git`, `template_path`, and that `template` names a directory under that path."
+            } else {
+                "Run `nockup channel update` or check your template-commit hash."
+            }
         );
     }
 
@@ -116,6 +134,49 @@ fn copy_and_render_template(
 
     copy_dir_recursive(src_dir, dest_dir, &handlebars, context, dest_dir)?;
     Ok(())
+}
+
+/// Fetch a template from a git URL via [`GitFetcher`] and resolve the
+/// concrete template directory under it.
+///
+/// Layout:
+///   - When `template_path` is set, the template lives at
+///     `<repo>/<template_path>/<template_name>/`.
+///   - When unset, it lives at `<repo>/<template_name>/`.
+///
+/// `template_commit` pins the fetch to a specific revision; when unset
+/// `GitFetcher` resolves whatever the URL's HEAD points at. The cache
+/// directory is shared with the channel cache (`~/.nockup/templates/git/`)
+/// and keyed by URL hash + commit, so repeat fetches are no-ops.
+async fn resolve_git_template(
+    cache_dir: &Path,
+    git_url: &str,
+    template_commit: Option<&str>,
+    template_path: Option<&str>,
+    template_name: &str,
+) -> Result<PathBuf> {
+    let fetcher = GitFetcher::new(cache_dir.join("git"));
+    let spec = GitSpec {
+        url: git_url.to_string(),
+        commit: template_commit.map(str::to_string),
+        tag: None,
+        branch: None,
+        path: None,
+        install_path: None,
+        file: None,
+    };
+    let repo_root = fetcher
+        .fetch(&spec)
+        .await
+        .with_context(|| format!("Failed to fetch template repo {}", git_url))?;
+
+    let sub = template_path.unwrap_or("").trim_matches('/');
+    let resolved = if sub.is_empty() {
+        repo_root.join(template_name)
+    } else {
+        repo_root.join(sub).join(template_name)
+    };
+    Ok(resolved)
 }
 
 fn copy_dir_recursive(

--- a/crates/nockup/src/commands/external.rs
+++ b/crates/nockup/src/commands/external.rs
@@ -1,0 +1,48 @@
+//! External-subcommand dispatcher.
+//!
+//! When the user runs `nockup foo bar`, clap routes any unknown
+//! subcommand into [`Commands::External`]. We look up `nockup-foo` on
+//! `$PATH` (cargo's plugin convention) and exec it with `[bar, ...]`.
+//!
+//! Trust the full `$PATH`. Restricting to a sanctioned plugin dir
+//! breaks `cargo install nockup-foo` and `nix profile install`
+//! workflows for downstream tools.
+
+use std::ffi::OsString;
+use std::process::Command;
+
+use anyhow::Result;
+use colored::Colorize;
+
+pub async fn run(args: Vec<OsString>) -> Result<()> {
+    let (head, tail) = args
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("no subcommand provided"))?;
+
+    let name = head
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("subcommand name is not valid UTF-8"))?;
+    let bin = format!("nockup-{}", name);
+
+    let path = match which::which(&bin) {
+        Ok(p) => p,
+        Err(_) => {
+            anyhow::bail!(
+                "unknown command: {}\n\
+                 hint: install `{}` and put it on $PATH (cargo-style plugins)",
+                name.yellow(),
+                bin.cyan()
+            );
+        }
+    };
+
+    let status = Command::new(path)
+        .args(tail)
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to exec {}: {}", bin, e))?;
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}

--- a/crates/nockup/src/commands/mod.rs
+++ b/crates/nockup/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod build;
 pub mod cache;
 pub mod channel;
 pub mod common;
+pub mod external;
 pub mod init;
 pub mod package;
 pub mod run;

--- a/crates/nockup/src/commands/package/init.rs
+++ b/crates/nockup/src/commands/package/init.rs
@@ -29,12 +29,7 @@ pub async fn run(name: Option<String>) -> Result<()> {
     let pkg = HoonPackage {
         package: PackageMeta {
             name: dir_name.to_string(),
-            version: None,
-            description: None,
-            authors: None,
-            license: None,
-            template: None,
-            template_commit: None,
+            ..Default::default()
         },
         dependencies: Some(Default::default()),
     };

--- a/crates/nockup/src/main.rs
+++ b/crates/nockup/src/main.rs
@@ -44,6 +44,7 @@ async fn main() {
             .await
         }
         Some(Commands::TestPhase1) => commands::test_phase1::run().await,
+        Some(Commands::External(args)) => commands::external::run(args).await,
 
         None => version::show_version_info().await,
     };

--- a/crates/nockup/src/manifest.rs
+++ b/crates/nockup/src/manifest.rs
@@ -27,6 +27,19 @@ pub struct PackageMeta {
     pub template: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub template_commit: Option<String>,
+    /// Git URL of a repo containing template directories. When set,
+    /// `nockup project init` fetches the repo into the templates cache
+    /// and resolves `template` from `<cache>/<template_path>/<template>/`.
+    /// Accepts `https://`, `git@`, and `file://` URLs (the last is useful
+    /// for local testing). When unset, falls back to the channel-managed
+    /// `~/.nockup/templates/<template>/`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template_git: Option<String>,
+    /// Subdirectory inside `template_git` holding the templates root.
+    /// Defaults to repo root when omitted. Leading/trailing slashes are
+    /// stripped during resolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/crates/nockup/src/resolver/registry.rs
+++ b/crates/nockup/src/resolver/registry.rs
@@ -199,21 +199,42 @@ static REGISTRY: Lazy<HashMap<&'static str, RegistryEntry>> = Lazy::new(|| {
 /// Cached online registry
 static ONLINE_REGISTRY: Lazy<RwLock<Option<RegistryToml>>> = Lazy::new(|| RwLock::new(None));
 
-const REGISTRY_URL: &str =
+const DEFAULT_REGISTRY_URL: &str =
     "https://raw.githubusercontent.com/sigilante/typhoon/master/registry.toml";
 
-/// Fetch and parse the online registry (blocking - use spawn_blocking in async context)
+/// Resolve the registry URL, honoring `NOCKUP_REGISTRY_URL` if set.
+/// Accepts `https://`, `http://`, and `file://` URLs (the last reads
+/// directly via `std::fs`, useful for local testing).
+fn registry_url() -> String {
+    std::env::var("NOCKUP_REGISTRY_URL").unwrap_or_else(|_| DEFAULT_REGISTRY_URL.to_string())
+}
+
+/// Emit a stderr warning the first time the env-var override is observed.
+/// `Lazy::force` ensures the closure runs at most once per process.
+static OVERRIDE_NOTICE: Lazy<()> = Lazy::new(|| {
+    if let Ok(v) = std::env::var("NOCKUP_REGISTRY_URL") {
+        use colored::Colorize;
+        eprintln!("{} using NOCKUP_REGISTRY_URL={}", "warning:".yellow(), v);
+    }
+});
+
+/// Fetch and parse the registry (blocking — use spawn_blocking in async context).
 fn fetch_registry_sync() -> Result<RegistryToml> {
-    let response =
-        reqwest::blocking::get(REGISTRY_URL).context("Failed to fetch registry from GitHub")?;
+    Lazy::force(&OVERRIDE_NOTICE);
+    let url = registry_url();
 
-    let content = response
-        .text()
-        .context("Failed to read registry response")?;
+    let content = if let Some(path) = url.strip_prefix("file://") {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read registry from {}", path))?
+    } else {
+        reqwest::blocking::get(&url)
+            .with_context(|| format!("Failed to fetch registry from {}", url))?
+            .text()
+            .context("Failed to read registry response")?
+    };
 
-    let registry: RegistryToml =
-        toml::from_str(&content).context("Failed to parse registry TOML")?;
-
+    let registry: RegistryToml = toml::from_str(&content)
+        .with_context(|| format!("registry at {} did not parse as typhoon TOML", url))?;
     Ok(registry)
 }
 

--- a/crates/nockup/tests/extension_hooks.rs
+++ b/crates/nockup/tests/extension_hooks.rs
@@ -1,0 +1,175 @@
+//! Integration tests for the three downstream-facing extension hooks
+//! introduced in `extension-hooks`:
+//!
+//! * `template_git` / `template_path` in `nockapp.toml`
+//! * `nockup-<subcmd>` plugin discovery
+//!
+//! The `NOCKUP_REGISTRY_URL` env-var override has its own test binary
+//! (`tests/registry_override.rs`) because it touches the process-global
+//! `ONLINE_REGISTRY` cache and would race with the other tests.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Helper: initialize a real git repo at `path` with the given files,
+/// commit, return the commit hash.
+fn init_git_repo(path: &Path, files: &[(&str, &str)]) -> String {
+    StdCommand::new("git")
+        .arg("init")
+        .arg("--quiet")
+        .arg("-b")
+        .arg("main")
+        .current_dir(path)
+        .status()
+        .expect("git init");
+    StdCommand::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(path)
+        .status()
+        .expect("git config email");
+    StdCommand::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(path)
+        .status()
+        .expect("git config name");
+    for (relpath, content) in files {
+        let p = path.join(relpath);
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, content).unwrap();
+    }
+    StdCommand::new("git")
+        .args(["add", "-A"])
+        .current_dir(path)
+        .status()
+        .expect("git add");
+    StdCommand::new("git")
+        .args(["commit", "--quiet", "-m", "init"])
+        .current_dir(path)
+        .status()
+        .expect("git commit");
+    let out = StdCommand::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .output()
+        .expect("git rev-parse");
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+#[test]
+fn template_git_file_url_resolves() {
+    // Set up: a temp git repo with `templates/demo/{Cargo.toml, hoon/app/app.hoon}`.
+    let repo = TempDir::new().unwrap();
+    let _commit = init_git_repo(
+        repo.path(),
+        &[
+            ("templates/demo/Cargo.toml", "name = \"{{project_name}}\"\n"),
+            ("templates/demo/hoon/app/app.hoon", "::  marker\n"),
+        ],
+    );
+
+    // Set up: a working dir with a nockapp.toml pointing at the file:// URL.
+    let workdir = TempDir::new().unwrap();
+    let manifest = format!(
+        "[package]\nname = \"my-app\"\nversion = \"0.1.0\"\ntemplate = \"demo\"\ntemplate_git = \"file://{}\"\ntemplate_path = \"templates\"\n",
+        repo.path().display()
+    );
+    fs::write(workdir.path().join("nockapp.toml"), manifest).unwrap();
+
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("project")
+        .arg("init")
+        .current_dir(workdir.path())
+        // Isolate the templates cache so the test doesn't pollute ~/.nockup.
+        .env("HOME", workdir.path())
+        .assert()
+        .success();
+
+    // Assert the scaffold landed under <workdir>/my-app/
+    let scaffold = workdir.path().join("my-app");
+    assert!(scaffold.join("Cargo.toml").exists());
+    assert!(scaffold.join("hoon/app/app.hoon").exists());
+    let cargo = fs::read_to_string(scaffold.join("Cargo.toml")).unwrap();
+    assert!(
+        cargo.contains("name = \"my-app\""),
+        "handlebars rendered project_name: got {cargo:?}"
+    );
+}
+
+#[test]
+fn template_git_falls_back_when_unset() {
+    // No template_git, no cache populated → init must error with the
+    // existing "Template not found" message and not panic.
+    let workdir = TempDir::new().unwrap();
+    fs::write(
+        workdir.path().join("nockapp.toml"),
+        "[package]\nname = \"my-app\"\nversion = \"0.1.0\"\ntemplate = \"nonexistent-template\"\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("project")
+        .arg("init")
+        .current_dir(workdir.path())
+        .env("HOME", workdir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn plugin_discovery_executes_path_binary() {
+    // Drop a `nockup-greet` shell script into a tempdir, prepend that dir
+    // to PATH, invoke `nockup greet hello`, assert the binary ran and
+    // its exit code propagated.
+    let plugin_dir = TempDir::new().unwrap();
+    let script = plugin_dir.path().join("nockup-greet");
+    fs::write(
+        &script,
+        "#!/bin/sh\necho \"plugin says: $1\"\nexit 0\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+    }
+
+    let path_var = format!(
+        "{}:{}",
+        plugin_dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("greet")
+        .arg("hello")
+        .env("PATH", &path_var)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("plugin says: hello"));
+}
+
+#[test]
+fn plugin_discovery_missing_binary_errors() {
+    // Empty PATH → plugin lookup fails with the structured "unknown
+    // command" message, exit code non-zero.
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("nonexistent-cmd")
+        .env("PATH", "/nonexistent")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown command"));
+}

--- a/crates/nockup/tests/registry_override.rs
+++ b/crates/nockup/tests/registry_override.rs
@@ -1,0 +1,126 @@
+//! Integration tests for `NOCKUP_REGISTRY_URL`.
+//!
+//! These live in their own test binary so the process-global
+//! `ONLINE_REGISTRY` cache (in `crates/nockup/src/resolver/registry.rs`)
+//! doesn't bleed between tests in `extension_hooks.rs`.
+//!
+//! `nockup package add` only mutates `nockapp.toml`; the actual
+//! registry lookup happens in `package install`. So each test seeds
+//! a manifest with a dep entry and runs `install`.
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Write a minimal typhoon-shaped registry. Returns the `file://` URL.
+fn write_local_registry(dir: &std::path::Path, package_name: &str, git_url: &str) -> String {
+    let body = format!(
+        r#"
+[workspace.testws]
+git_url = "{git_url}"
+ref = "main"
+description = "test workspace"
+root_path = "."
+
+[[package]]
+name = "{package_name}"
+workspace = "testws"
+path = "."
+file = ""
+dependencies = []
+"#
+    );
+    let path = dir.join("registry.toml");
+    fs::write(&path, body).unwrap();
+    format!("file://{}", path.display())
+}
+
+/// Set up a project dir with `nockapp.toml` declaring one dep that
+/// will trigger registry lookup on `package install`.
+fn project_with_dep(dir: &std::path::Path, dep: &str) {
+    fs::create_dir_all(dir.join("probe")).unwrap();
+    fs::write(
+        dir.join("probe/nockapp.toml"),
+        format!(
+            "[package]\nname = \"probe\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"{dep}\" = \"latest\"\n"
+        ),
+    )
+    .unwrap();
+    // Mirror the manifest at the parent dir so `package install` can find
+    // the project from cwd.
+    fs::write(
+        dir.join("nockapp.toml"),
+        format!(
+            "[package]\nname = \"probe\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"{dep}\" = \"latest\"\n"
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn registry_env_override_emits_warning() {
+    let dir = TempDir::new().unwrap();
+    project_with_dep(dir.path(), "test/fakepkg");
+    let registry_url = write_local_registry(
+        dir.path(),
+        "test/fakepkg",
+        "https://example.invalid/does-not-exist",
+    );
+
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("package")
+        .arg("install")
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .env("NOCKUP_REGISTRY_URL", &registry_url)
+        .assert()
+        // Registry-lookup will fail downstream when the bogus git URL
+        // can't clone, but the override warning fires first.
+        .stderr(predicate::str::contains("NOCKUP_REGISTRY_URL"));
+}
+
+#[test]
+fn registry_env_override_file_url_parses() {
+    let dir = TempDir::new().unwrap();
+    project_with_dep(dir.path(), "test/fakepkg");
+    let registry_url = write_local_registry(
+        dir.path(),
+        "test/fakepkg",
+        "https://example.invalid/does-not-exist",
+    );
+
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("package")
+        .arg("install")
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .env("NOCKUP_REGISTRY_URL", &registry_url)
+        .assert()
+        // The registry parsed (no "did not parse"); install may still fail
+        // when the bogus git URL can't clone — that's downstream.
+        .stderr(predicate::str::contains("did not parse").not());
+}
+
+#[test]
+fn registry_env_override_bad_toml_reports_url() {
+    let dir = TempDir::new().unwrap();
+    project_with_dep(dir.path(), "test/fakepkg");
+
+    let bad_path = dir.path().join("bad-registry.toml");
+    fs::write(&bad_path, "this is not valid toml [[[").unwrap();
+    let bad_url = format!("file://{}", bad_path.display());
+
+    Command::cargo_bin("nockup")
+        .unwrap()
+        .arg("package")
+        .arg("install")
+        .current_dir(dir.path())
+        .env("HOME", dir.path())
+        .env("NOCKUP_REGISTRY_URL", &bad_url)
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## What this changes

Three additive hooks let a package or downstream tool extend nockup without a nockchain-monorepo PR:

| Hook | Where | Use |
|---|---|---|
| `template_git` / `template_path` in `nockapp.toml` `[package]` | `crates/nockup/src/manifest.rs`, `crates/nockup/src/commands/build/init.rs` | Fetch templates from any git URL (incl. `file://`) |
| `nockup-<subcmd>` plugin discovery (cargo-style) | `crates/nockup/src/cli.rs`, `crates/nockup/src/commands/external.rs` | External subcommands resolved via `$PATH` |
| `NOCKUP_REGISTRY_URL` env var | `crates/nockup/src/resolver/registry.rs` | Override the typhoon registry source (incl. `file://`) |

## Why

Concrete motivating case: vesl-nockup. Today every template tweak, graft-inject change, or new graft would require a PR to nockchain. With these hooks, vesl-nockup ships its own `vesl` template, distributes `nockup-graft` as a plugin binary built from the same source as `graft-inject`, and gates CI against a local-fork registry via `NOCKUP_REGISTRY_URL`. Zero further upstream review for ongoing iteration on vesl features.

The same shape works for any project that wants to ship templates, subcommands, or alternative registries on top of nockup.

## CLI additions

- `nockapp.toml`'s `[package]` block accepts two new fields:
  - `template_git = "<url>"` — git URL of the template repo
  - `template_path = "<subdir>"` — parent directory holding templates (defaults to repo root). The cache shape is `~/.nockup/templates/git/<url-hash>/<commit>/<template_path>/<template>/`, keyed identically to the existing `GitFetcher` scheme.
- Unknown subcommands are no longer a hard error. `nockup foo bar baz` looks up `nockup-foo` on `$PATH` via `which::which` and execs with `[bar, baz]`. Exit code propagates. On miss, prints `error: unknown command: foo\nhint: install 'nockup-foo' and put it on $PATH (cargo-style plugins)`.
- `NOCKUP_REGISTRY_URL` accepts `https://`, `http://`, and `file://`. The first time the override is observed, nockup emits `warning: using NOCKUP_REGISTRY_URL=<value>` to stderr (cargo's override-warning style).

## Backwards compatibility

Each hook is purely additive:

- Manifests without `template_git` / `template_path` resolve through the existing `~/.nockup/templates/<name>/` channel cache. The new fields are `#[serde(default, skip_serializing_if = "Option::is_none")]`, so they round-trip cleanly through `NockAppManifest::save`.
- Existing CLI invocations (built-in subcommands, legacy flat commands) hit their existing match arms before the new `External` variant fires. clap's `external_subcommand` only catches tokens it doesn't otherwise recognize.
- Without `NOCKUP_REGISTRY_URL` set, `registry_url()` returns the hardcoded typhoon URL — same behavior as before.
- The `OVERRIDE_NOTICE: Lazy<()>` is silent unless the env var is set.

## Dependencies

`which` is already in workspace deps for `package install`'s git tooling. No new crates.

## Testing

Two test binaries:

- `crates/nockup/tests/extension_hooks.rs` — 4 tests covering `template_git` resolution against a `file://` git fixture, the existing-cache fall-through error path, and plugin discovery happy + missing paths.
- `crates/nockup/tests/registry_override.rs` — 3 tests in their own binary so the process-global `ONLINE_REGISTRY` cache doesn't bleed into `extension_hooks` tests. Covers warn-once stderr, file:// URL parse, and malformed-TOML failure mode.

End-to-end smoke against the downstream vesl template exercises all three hooks together and asserts on the scaffolded files.

## Open questions

- **`template_path` semantics**: parent-of-templates (chosen) vs. is-template-itself. Picked the former so a downstream repo can ship multiple templates (`vesl`, `vesl-counter`, etc.) under one git URL without forking. Matches the existing `~/.nockup/templates/<name>/` layout.
- **Help-text plugin enumeration**: cargo lists `cargo-*` binaries on `$PATH` in `cargo --list`. Same is feasible for nockup but needs a `walkdir`-style scan; deferred as a follow-up so this PR stays small.
- **Registry test isolation**: `ONLINE_REGISTRY` is a process-global `Lazy<RwLock<...>>`. Tests live in a separate test binary (`tests/registry_override.rs`) so the cache doesn't bleed across tests. The alternative was a `#[cfg(test)]` reset hook; rejected as invasive for what the test binary boundary handles cleanly.

## Test plan

- [ ] `cargo +nightly test -p nockup --test extension_hooks` — 4/4 pass
- [ ] `cargo +nightly test -p nockup --test registry_override -- --test-threads=1` — 3/3 pass
- [ ] `cargo +nightly test -p nockup --lib` — no regressions in inline unit tests
- [ ] Fresh `nockup project init` from a `nockapp.toml` with `template_git = "file:///tmp/test-template-repo"` produces the expected scaffold.
- [ ] `nockup foo bar` with `nockup-foo` on `$PATH` execs the binary and propagates exit code; without it on `$PATH`, prints the "unknown command" hint with non-zero exit.
- [ ] `NOCKUP_REGISTRY_URL=file:///tmp/registry.toml nockup package install` (with a dep declared) reads the local file and emits the override warning to stderr.
- [ ] No regression: existing manifests, invocations, and registry lookups behave identically when the new fields/var/binaries are absent.