### PR TITLE
http driver: add HTTP_PORT env var for local port override

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,23 @@ You can also add this to your `.env` file if you're running with the Makefile:
 RUST_LOG=info
 ```
 
+### How do I change the HTTP port?
+
+When the HTTP driver runs in local mode (i.e. `HTTPS_DOMAIN` is unset or set to a
+local domain such as `localhost`, `127.*`, `192.168.*`, or `*.local`), it binds to
+`127.0.0.1:8080` by default. You can override the port with the `HTTP_PORT`
+environment variable:
+
+```bash
+# Serve the local HTTP interface on port 3000 instead of 8080
+HTTP_PORT=3000 nockchain
+```
+
+`HTTP_PORT` must be a valid port number (0–65535); an invalid value causes the
+driver to fail at startup. In production mode (a non-local `HTTPS_DOMAIN`), the
+driver continues to use the standard ports 80 (for ACME challenges) and 443 (for
+HTTPS), which are not affected by `HTTP_PORT`.
+
 ### How do profile for performance?
 
 Here's a demo video for the Tracy integration in Nockchain: https://x.com/nockchain/status/1948109668171051363

--- a/crates/nockapp/src/drivers/http/http.rs
+++ b/crates/nockapp/src/drivers/http/http.rs
@@ -57,6 +57,8 @@ pub enum HttpError {
     AcmeError(#[from] anyhow::Error),
     #[error("Environment variable error: {0}")]
     EnvError(#[from] env::VarError),
+    #[error("Invalid HTTP_PORT value: {0}")]
+    InvalidPort(String),
     #[error("Noun processing error: {0}")]
     NounError(#[from] nockvm::noun::Error),
 }
@@ -179,6 +181,11 @@ pub fn http() -> IODriverFn {
         let domain = env::var("HTTPS_DOMAIN").unwrap_or_else(|_| "localhost".to_string());
         // Directory to serve static files from
         let web_dir = env::var("WEB_DIR").ok();
+        // Port to bind to in local mode (production uses the standard 80/443).
+        let local_port = match env::var("HTTP_PORT") {
+            Ok(s) => s.parse::<u16>().map_err(|_| HttpError::InvalidPort(s))?,
+            Err(_) => 8080,
+        };
 
         // Check if we're running locally
         let is_local = domain == "localhost"
@@ -266,10 +273,11 @@ pub fn http() -> IODriverFn {
         };
 
         if is_local {
-            // Local development: just run HTTP on port 8080
-            let http_listener = tokio::net::TcpListener::bind("127.0.0.1:8080")
-                .await
-                .map_err(HttpError::BindError)?;
+            // Local development: run HTTP on 127.0.0.1, port from HTTP_PORT (default 8080)
+            let http_listener =
+                tokio::net::TcpListener::bind(("127.0.0.1", local_port))
+                    .await
+                    .map_err(HttpError::BindError)?;
             let http_addr = http_listener
                 .local_addr()
                 .map_err(|_| HttpError::LocalAddrError)?;

--- a/crates/nockapp/src/drivers/http/http.rs
+++ b/crates/nockapp/src/drivers/http/http.rs
@@ -274,10 +274,9 @@ pub fn http() -> IODriverFn {
 
         if is_local {
             // Local development: run HTTP on 127.0.0.1, port from HTTP_PORT (default 8080)
-            let http_listener =
-                tokio::net::TcpListener::bind(("127.0.0.1", local_port))
-                    .await
-                    .map_err(HttpError::BindError)?;
+            let http_listener = tokio::net::TcpListener::bind(("127.0.0.1", local_port))
+                .await
+                .map_err(HttpError::BindError)?;
             let http_addr = http_listener
                 .local_addr()
                 .map_err(|_| HttpError::LocalAddrError)?;


### PR DESCRIPTION
## Summary

The library `http_driver()` hardcoded `127.0.0.1:8080` in local mode with no way to override the port. This made it impossible to run multiple instances or fit into an existing port layout without writing a replacement driver — which is also impractical because the effect-parsing logic is inlined (not exported) in `http()`.

This PR adds an `HTTP_PORT` environment variable so the local bind port can be configured directly.

## Changes

- Read `HTTP_PORT` (default `8080`) alongside the other HTTP env vars (`HTTPS_DOMAIN`, `WEB_DIR`, …).
- Bind local mode to `("127.0.0.1", local_port)` instead of the hardcoded `127.0.0.1:8080`.
- New `HttpError::InvalidPort(String)` variant so a non-numeric/out-of-range value fails loudly at startup rather than silently.
- Documented `HTTP_PORT` in `README.md`.

## Scope

- **Local mode only.** Production mode (a non-local `HTTPS_DOMAIN`) is unchanged and continues to use the standard ports 80 (ACME challenges) and 443 (HTTPS).
- Follows the existing unprefixed env-var convention in the HTTP driver.

## Testing

`cargo check -p nockapp` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)